### PR TITLE
Napari 0.7.0 compatibility, layer selection, and Split Stack widget

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ write_to = "src/napari_timestamper/_version.py"
 
 [tool.black]
 line-length = 79
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313']
 
 
 [tool.ruff]
@@ -54,5 +54,5 @@ exclude = [
     "*_vendor*",
 ]
 
-target-version = 'py39'
+target-version = 'py310'
 fix = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -35,7 +34,7 @@ install_requires =
     numpy
     qtpy
 
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 package_dir =
     =src
@@ -54,7 +53,7 @@ testing =
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt  # https://pytest-qt.readthedocs.io/en/latest/
-    napari >= 0.5.0
+    napari >= 0.6.1
     pyqt5
 
 

--- a/src/napari_timestamper/__init__.py
+++ b/src/napari_timestamper/__init__.py
@@ -12,6 +12,7 @@ from ._widget import (
     LayerAnnotationsWidget,
     LayertoRGBWidget,
     RenderRGBWidget,
+    SplitStackWidget,
     TimestampWidget,
 )
 from .render_as_rgb import render_as_rgb, save_image_stack
@@ -21,6 +22,7 @@ __all__ = (
     "LayerAnnotationsWidget",
     "RenderRGBWidget",
     "LayertoRGBWidget",
+    "SplitStackWidget",
     "TimestampOverlay",
     "VispyTimestampOverlay",
     "LayerAnnotatorOverlay",

--- a/src/napari_timestamper/_layer_annotator_overlay.py
+++ b/src/napari_timestamper/_layer_annotator_overlay.py
@@ -95,7 +95,7 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
     Vispy Timestamp Overlay.
     """
 
-    RECTANGLE_SCALER = 2
+    RECTANGLE_SCALER = 3
     ANCHOR_CORRECTION = 0.5
 
     def __init__(self, *, viewer, overlay, parent=None, **kwargs):
@@ -247,6 +247,7 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
             layers_to_annotate["colors"] = ColorArray(["white"])
 
         self.overlay.layers_to_annotate = layers_to_annotate
+        self._on_property_change()
 
     def _on_viewer_zoom_change(self, event=None):
         """
@@ -267,6 +268,10 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
         """
         Callback function for when the position of the overlay is changed.
         """
+        layers = self.overlay.layers_to_annotate
+        if not layers.get("layer_names"):
+            return
+
         max_layer_scale = self._get_max_layer_scale()
         position = self.overlay.position
         y_max, x_max = (
@@ -274,14 +279,14 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
             self.viewer.dims.range[-1][-2],
         )
 
-        if len(self.overlay.layers_to_annotate["y_offsets"]) < 1:
-            self.overlay.layers_to_annotate["y_offsets"] = [0]
-        if len(self.overlay.layers_to_annotate["x_offsets"]) < 1:
-            self.overlay.layers_to_annotate["x_offsets"] = [0]
-        if len(self.overlay.layers_to_annotate["layer_widths"]) < 1:
-            self.overlay.layers_to_annotate["layer_widths"] = [0]
-        if len(self.overlay.layers_to_annotate["layer_scales"]) < 1:
-            self.overlay.layers_to_annotate["layer_scales"] = [1]
+        if len(layers.get("y_offsets", [])) < 1:
+            layers["y_offsets"] = [0]
+        if len(layers.get("x_offsets", [])) < 1:
+            layers["x_offsets"] = [0]
+        if len(layers.get("layer_widths", [])) < 1:
+            layers["layer_widths"] = [0]
+        if len(layers.get("layer_scales", [])) < 1:
+            layers["layer_scales"] = [1]
 
         if position == ScenePosition.TOP_LEFT:
             y_offsets, x_offsets = self.correct_offsets_for_overlap("down")
@@ -421,6 +426,12 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
         """
         Callback function for when properties of the overlay are changed.
         """
+        layers = self.overlay.layers_to_annotate
+        if not layers.get("layer_names"):
+            self.node._rectagles_visual.visible = False
+            self.node.show_outline = False
+            return
+
         if self.viewer.dims.ndisplay == 3:
             self.node.show_outline = False
             self.node._rectagles_visual.visible = False
@@ -428,14 +439,14 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
             self.node.show_outline = self.overlay.show_outline
             self.node._rectagles_visual.visible = self.overlay.show_background
 
-        self.node.text = self.overlay.layers_to_annotate["layer_names"]
+        self.node.text = layers["layer_names"]
         self.node.bold = self.overlay.bold
         self.node.italic = self.overlay.italic
         self.node.outline_color = self.overlay.outline_color
         self.node.outline_thickness = self.overlay.outline_thickness
         self.node.bgcolor = self.overlay.bg_color.rgba.tolist()
         if self.overlay.use_layer_color:
-            self.node.color = self.overlay.layers_to_annotate["colors"]
+            self.node.color = layers.get("colors", self.overlay.color)
         else:
             self.node.color = self.overlay.color
         self._on_size_change()

--- a/src/napari_timestamper/_layer_annotator_overlay.py
+++ b/src/napari_timestamper/_layer_annotator_overlay.py
@@ -18,6 +18,7 @@ from typing import Literal
 from napari._vispy.overlays.base import ViewerOverlayMixin, VispySceneOverlay
 from napari.components.overlays import SceneOverlay
 from napari.layers import Image, labels
+from pydantic import ConfigDict
 from vispy.color import ColorArray
 from vispy.visuals.transforms import STTransform
 
@@ -62,6 +63,8 @@ class LayerAnnotatorOverlay(SceneOverlay):
     Timestamp Overlay.
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     color: str = "white"
     use_layer_color: bool = False
     size: int = 12
@@ -95,7 +98,7 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
     RECTANGLE_SCALER = 2
     ANCHOR_CORRECTION = 0.5
 
-    def __init__(self, *, viewer, overlay, parent=None):
+    def __init__(self, *, viewer, overlay, parent=None, **kwargs):
         super().__init__(
             node=TextWithBoxVisual(
                 text=overlay.layers_to_annotate["layer_names"],
@@ -108,6 +111,7 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
             viewer=viewer,
             overlay=overlay,
             parent=parent,
+            **kwargs,
         )
         self.camera_scale_factor = 1
         self.x_spacer = self.overlay.x_spacer

--- a/src/napari_timestamper/_layer_annotator_overlay.py
+++ b/src/napari_timestamper/_layer_annotator_overlay.py
@@ -97,6 +97,7 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
 
     RECTANGLE_SCALER = 3
     ANCHOR_CORRECTION = 0.5
+    selected_layer_names = None  # None means all layers
 
     def __init__(self, *, viewer, overlay, parent=None, **kwargs):
         super().__init__(
@@ -202,41 +203,48 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
         layer_translations.reverse()  # Reverse order to match layer order
 
         for i, layer in enumerate(self.viewer.layers[::-1]):
-            if layer.visible:
-                layers_to_annotate["layer_names"].append(layer.name)
-                layers_to_annotate["hidden_outlines"].append(
-                    self._outlines_to_hide(i, len(self.viewer.layers))
-                )
+            if not layer.visible:
+                continue
+            if (
+                self.selected_layer_names is not None
+                and layer.name not in self.selected_layer_names
+            ):
+                continue
 
-                # Get color information
-                if isinstance(layer, labels.Labels):
+            layers_to_annotate["layer_names"].append(layer.name)
+            layers_to_annotate["hidden_outlines"].append(
+                self._outlines_to_hide(i, len(self.viewer.layers))
+            )
+
+            # Get color information
+            if isinstance(layer, labels.Labels):
+                layers_to_annotate["colors"].append(self.overlay.color)
+            else:
+                try:
+                    layers_to_annotate["colors"].append(
+                        layer.colormap.colors[-1]
+                    )
+                except AttributeError:
                     layers_to_annotate["colors"].append(self.overlay.color)
-                else:
-                    try:
-                        layers_to_annotate["colors"].append(
-                            layer.colormap.colors[-1]
-                        )
-                    except AttributeError:
-                        layers_to_annotate["colors"].append(self.overlay.color)
 
-                # Update offsets based on grid position
-                grid_offset = layer_translations[i]
+            # Update offsets based on grid position
+            grid_offset = layer_translations[i]
 
-                # Apply layer scale to offsets
-                layer_scale = getattr(layer, "scale", 1.0)[-1]
+            # Apply layer scale to offsets
+            layer_scale = getattr(layer, "scale", 1.0)[-1]
 
-                layers_to_annotate["y_offsets"].append(grid_offset[-2])
-                layers_to_annotate["x_offsets"].append(grid_offset[-1])
-                layers_to_annotate["layer_scales"].append(layer_scale)
+            layers_to_annotate["y_offsets"].append(grid_offset[-2])
+            layers_to_annotate["x_offsets"].append(grid_offset[-1])
+            layers_to_annotate["layer_scales"].append(layer_scale)
 
-                # Apply scale to layer widths as well
-                if not isinstance(layer, (Image, labels.Labels)):
-                    extent = self.viewer._sliced_extent_world_augmented
-                    width = extent[1][-2] - extent[0][-2]
-                    layers_to_annotate["layer_widths"].append(width)
-                else:
-                    width = layer.data.shape[-2:][1]
-                    layers_to_annotate["layer_widths"].append(width)
+            # Apply scale to layer widths as well
+            if not isinstance(layer, (Image, labels.Labels)):
+                extent = self.viewer._sliced_extent_world_augmented
+                width = extent[1][-2] - extent[0][-2]
+                layers_to_annotate["layer_widths"].append(width)
+            else:
+                width = layer.data.shape[-2:][1]
+                layers_to_annotate["layer_widths"].append(width)
 
         # Convert colors to ColorArray
         try:

--- a/src/napari_timestamper/_layer_annotator_overlay.py
+++ b/src/napari_timestamper/_layer_annotator_overlay.py
@@ -1,67 +1,122 @@
 """
-This module contains the LayerAnnotatorOverlay and VispyLayerAnnotatorOverlay classes.
+LayerAnnotatorOverlay for napari >= 0.6.2 (ViewBox-based grid mode).
 
-The LayerAnnotatorOverlay class is the napari layer annotator overlay. It contains the
-properties of the overlay. The VispyLayerAnnotatorOverlay class is the vispy layer
-annotator overlay. It contains the functionality of the overlay
-and the vispy visual that is drawn in the canvas. The vispy visual is a TextWithBoxVisual
-that contains the text and box visuals that are drawn in the canvas
-and the properties of the visuals.
+BLENDING / DFS DRAW ORDER FIX
+-------------------------------
+vispy._generate_draw_order is a DFS. Children always render inside their
+parent's bracket:
 
-This structure is adapted from the napari dev example.
+    (Layer1, True) → (OurOverlay, True/False) → (Layer1, False)
+    (Layer2, True) ...
+
+Layer2 renders after OurOverlay even though OurOverlay.order=1000000,
+because order only sorts SIBLINGS at each DFS level.  Layer2's additive
+blending then composites on top of OurOverlay's black background.
+
+Fix: re-parent from the layer node to the ViewBox scene (its sibling level).
+OurOverlay then becomes a sibling of all layer nodes and, with order=1000000,
+renders after every layer.
+
+_update_scenegraph (triggered by grid.enabled/shape/stride/spacing,
+layers.reordered, layer add/remove) calls _update_layer_overlays which
+always resets node.parent back to layer_node.  We fix this by:
+
+  1. Saving self._layer_node = parent at creation time.
+  2. Calling _reparent_to_viewbox_scene() — which uses
+     self._layer_node.parent as the reliable, always-current target —
+     at the start of every _on_position_change and _on_visible_change.
+  3. Connecting to ALL events that trigger _update_scenegraph.
+
+EVENT CONNECTIONS
+-----------------
+Events that trigger _update_scenegraph → _update_layer_overlays (resets parent):
+  viewer.grid.events.enabled   ← was connected, now also re-parents
+  viewer.grid.events.shape     ← NEW
+  viewer.grid.events.stride    ← NEW
+  viewer.grid.events.spacing   ← NEW
+  viewer.layers.events.reordered  ← was connected, now also re-parents
+  viewer.layers.events.inserted   ← was connected, now also re-parents
+  viewer.layers.events.removed    ← was connected, now also re-parents
+  layer.events.visible            ← handled in _on_visible_change override
+
+VISIBILITY FIX
+--------------
+Previously node.visible was only restored inside `if grid.enabled:`, so
+switching grid off left the node hidden if the image had scrolled out of
+view.  We now reset visibility at the TOP of _on_position_change so it is
+always correct before any branch runs.
+
+LAYOUT
+------
+anchor_y = "bottom" everywhere; rect extends DOWNWARD from pos_y.
+TOP:    y_base = y_min + idx * step   (inside image, stacks down)
+BOTTOM: y_base = y_max - (idx+1)*step (inside image, stacks up)
+Width from shape×scale (avoids pixel-centre 1-px shortfall).
 """
 
-import contextlib
-from collections import defaultdict
-from typing import Literal
+from __future__ import annotations
 
-from napari._vispy.overlays.base import ViewerOverlayMixin, VispySceneOverlay
+import contextlib
+from typing import TYPE_CHECKING, Any
+
+from napari._vispy.overlays.base import LayerOverlayMixin, VispySceneOverlay
+from napari._vispy.utils.gl import BLENDING_MODES
+from napari._vispy.utils.visual import overlay_to_visual
 from napari.components.overlays import SceneOverlay
-from napari.layers import Image, labels
+from napari.layers import labels
 from pydantic import ConfigDict
 from vispy.color import ColorArray
-from vispy.visuals.transforms import STTransform
 
 from napari_timestamper.text_visual import TextWithBoxVisual
-from napari_timestamper.utils import _find_grid_offsets
 
+if TYPE_CHECKING:
+    from napari.components import ViewerModel
+    from napari.layers import Layer
+    from vispy.scene import Node
+
+
+# ---------------------------------------------------------------------------
+# Position enum
+# ---------------------------------------------------------------------------
 try:
-    from napari.utils.compat import StrEnum
+    from napari.components._viewer_constants import (
+        CanvasPosition as ScenePosition,
+    )
 except ImportError:
     import enum
 
-    class StrEnum(str, enum.Enum):
-        """Enum where members are also (and must be) strings"""
+    class ScenePosition(str, enum.Enum):
+        TOP_LEFT = "top_left"
+        TOP_CENTER = "top_center"
+        TOP_RIGHT = "top_right"
+        BOTTOM_RIGHT = "bottom_right"
+        BOTTOM_CENTER = "bottom_center"
+        BOTTOM_LEFT = "bottom_left"
 
-        def _generate_next_value_(name, start, count, last_values):
-            """Generate an enum member."""
-            return name
+
+CanvasPosition = ScenePosition
 
 
-class ScenePosition(StrEnum):
-    """Canvas overlay position.
+# ---------------------------------------------------------------------------
+# Anchor map (anchor_y always "bottom" → rect extends DOWNWARD)
+# ---------------------------------------------------------------------------
+_ANCHOR_MAP: dict[str, tuple[str, str]] = {
+    "top_left": ("left", "bottom"),
+    "top_center": ("center", "bottom"),
+    "top_right": ("right", "bottom"),
+    "bottom_left": ("left", "bottom"),
+    "bottom_center": ("center", "bottom"),
+    "bottom_right": ("right", "bottom"),
+}
 
-    Sets the position of an object in the canvas
-            * top_left: Top left of the canvas
-            * top_right: Top right of the canvas
-            * top_center: Top center of the canvas
-            * bottom_right: Bottom right of the canvas
-            * bottom_left: Bottom left of the canvas
-            * bottom_center: Bottom center of the canvas
-    """
 
-    TOP_LEFT = "top_left"
-    TOP_CENTER = "top_center"
-    TOP_RIGHT = "top_right"
-    BOTTOM_RIGHT = "bottom_right"
-    BOTTOM_CENTER = "bottom_center"
-    BOTTOM_LEFT = "bottom_left"
+# ---------------------------------------------------------------------------
+# Overlay model
+# ---------------------------------------------------------------------------
 
 
 class LayerAnnotatorOverlay(SceneOverlay):
-    """
-    Timestamp Overlay.
-    """
+    """Scene overlay that draws the layer name at a corner of the layer image."""
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -74,61 +129,75 @@ class LayerAnnotatorOverlay(SceneOverlay):
     bg_color: ColorArray = ColorArray(["black"])
     show_outline: bool = False
     outline_color: ColorArray = ColorArray(["white"])
-    outline_thickness: float = 1
+    outline_thickness: float = 1.0
     show_background: bool = False
-    y_spacer: int = 0
-    x_spacer: int = 0
-    layers_to_annotate: dict = {
-        "layer_names": ["None"],
-        "y_offsets": [0],
-        "x_offsets": [0],
-        "layer_widths": [0],
-        "colors": ColorArray(["white"]),
-        "layer_scales": [1],
-        "hidden_outlines": None,
-    }
 
 
-# probably should make this as a layer overlay.... no time at the moment tho :(
-class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
+# ---------------------------------------------------------------------------
+# Vispy backend
+# ---------------------------------------------------------------------------
+
+
+class VispyLayerAnnotatorOverlay(LayerOverlayMixin, VispySceneOverlay):
     """
-    Vispy Timestamp Overlay.
+    Renders a layer-name label in world/scene space for one layer.
+
+    Normally napari parents SceneOverlays to the layer's vispy node, but we
+    immediately re-parent to the ViewBox scene (one level up) so our
+    order=1000000 puts us after ALL layer nodes in vispy's DFS draw order.
     """
 
-    RECTANGLE_SCALER = 3
-    ANCHOR_CORRECTION = 0.5
-    selected_layer_names = None  # None means all layers
+    overlay: LayerAnnotatorOverlay
 
-    def __init__(self, *, viewer, overlay, parent=None, **kwargs):
+    def __init__(
+        self,
+        *,
+        viewer: ViewerModel,
+        overlay: LayerAnnotatorOverlay,
+        layer: Layer,
+        parent: Node | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(
             node=TextWithBoxVisual(
-                text=overlay.layers_to_annotate["layer_names"],
-                color=overlay.layers_to_annotate["colors"],
+                text=[layer.name],
+                color=self._layer_color(layer, overlay),
                 font_size=overlay.size,
                 pos=(0, 0),
                 bold=overlay.bold,
                 italic=overlay.italic,
             ),
+            layer=layer,
             viewer=viewer,
             overlay=overlay,
             parent=parent,
             **kwargs,
         )
-        self.camera_scale_factor = 1
-        self.x_spacer = self.overlay.x_spacer
-        self.y_spacer = self.overlay.y_spacer
-        self.x_size = 0
-        self.y_size = 0
-        self.node.transform = STTransform()
 
-        # setup callbacks
-        self.overlay.events.layers_to_annotate.connect(
-            self._on_property_change
-        )
+        # Save the layer's vispy node reference.  _reparent_to_viewbox_scene()
+        # uses self._layer_node.parent as the target, which napari keeps
+        # up-to-date as the layer moves between ViewBoxes on grid changes.
+        self._layer_node: Node | None = parent
+
+        # spacer=0: box edges align exactly with image boundary
+        self.node._rectagles_visual.spacer = 0
+
+        # Zoom scale: text grows with image
+        self._camera_zoom: float = max(self.viewer.camera.zoom, 1e-6)
+        self.node.scale_factor = self._camera_zoom
+
+        # --- layer events ---
+        self.layer.events.name.connect(self._on_property_change)
+        with contextlib.suppress(AttributeError):
+            self.layer.events.colormap.connect(self._on_property_change)
+        with contextlib.suppress(AttributeError):
+            self.layer.events.scale.connect(self._on_position_change)
+        with contextlib.suppress(AttributeError):
+            self.layer.events.translate.connect(self._on_position_change)
+
+        # --- overlay events ---
         self.overlay.events.size.connect(self._on_size_change)
         self.overlay.events.position.connect(self._on_position_change)
-        self.overlay.events.y_spacer.connect(self._update_offsets)
-        self.overlay.events.x_spacer.connect(self._update_offsets)
         self.overlay.events.color.connect(self._on_property_change)
         self.overlay.events.use_layer_color.connect(self._on_property_change)
         self.overlay.events.bold.connect(self._on_property_change)
@@ -138,334 +207,392 @@ class VispyLayerAnnotatorOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.overlay.events.show_outline.connect(self._on_property_change)
         self.overlay.events.outline_color.connect(self._on_property_change)
         self.overlay.events.outline_thickness.connect(self._on_property_change)
-        self.viewer.camera.events.zoom.connect(self._on_viewer_zoom_change)
-        self.viewer.layers.events.inserted.connect(self._on_new_layer_added)
-        self.viewer.layers.events.reordered.connect(self._update_annotations)
-        self.viewer.layers.events.removed.connect(self._update_annotations)
-        self.viewer.grid.events.shape.connect(self._update_annotations)
-        self.viewer.grid.events.stride.connect(self._update_annotations)
-        self.viewer.grid.events.enabled.connect(self._update_annotations)
+
+        # --- viewer events (all events that trigger _update_scenegraph) ---
+        self.viewer.camera.events.zoom.connect(self._on_zoom_change)
+        self.viewer.camera.events.center.connect(self._on_position_change)
         self.viewer.dims.events.ndisplay.connect(self._on_property_change)
 
+        # Grid events — ALL of these trigger _update_scenegraph
+        self.viewer.grid.events.enabled.connect(self._on_position_change)
+        self.viewer.grid.events.shape.connect(self._on_position_change)
+        self.viewer.grid.events.stride.connect(self._on_position_change)
+        self.viewer.grid.events.spacing.connect(self._on_position_change)
+
+        # Layer list events — also trigger _update_scenegraph
+        self.viewer.layers.events.reordered.connect(self._on_position_change)
+        self.viewer.layers.events.inserted.connect(self._on_position_change)
+        self.viewer.layers.events.removed.connect(self._on_position_change)
+
         self.reset()
-        self._connect_iniial_layers()
 
-    def _update_offsets(self, event=None):
+        # Re-parent AFTER reset().  Must be last in __init__ so napari hasn't
+        # had a chance to reset the parent back to layer_node yet.
+        self._reparent_to_viewbox_scene()
+
+    # ------------------------------------------------------------------
+    # Re-parenting
+    # ------------------------------------------------------------------
+
+    def _reparent_to_viewbox_scene(self) -> None:
         """
-        Callback function for when the offsets of the overlay are changed.
+        Move our node to be a sibling of the layer node (child of ViewBox scene).
+
+        Target = self._layer_node.parent, which napari keeps current:
+          - non-grid: self._layer_node.parent = self.view.scene
+          - grid:     self._layer_node.parent = specific_viewbox.scene
+
+        Using self._layer_node (saved at creation) instead of
+        self.node.parent avoids the "walk one level too high" bug that
+        occurs when we're already correctly parented.
         """
-        self.x_spacer = self.overlay.x_spacer
-        self.y_spacer = self.overlay.y_spacer
-        self._on_position_change()
-
-    def _connect_iniial_layers(self):
-        """
-        Connects the initial layers to the overlay.
-        """
-        for layer in self.viewer.layers:
-            layer.events.visible.connect(self._update_annotations)
-            layer.events.name.connect(self._update_annotations)
-            with contextlib.suppress(AttributeError):
-                layer.events.colormap.connect(self._update_annotations)
-
-    def _on_new_layer_added(self, event=None):
-        """
-        Callback function for when a new layer is added to the viewer.
-        """
-        layer = event.value
-        layer.events.visible.connect(self._update_annotations)
-        layer.events.name.connect(self._update_annotations)
-        with contextlib.suppress(AttributeError):
-            layer.events.colormap.connect(self._update_annotations)
-
-        self._update_annotations()
-
-    def _outlines_to_hide(self, current_layer, layer_number):
-        """
-        Returns the outlines to hide for the given layer number and current layer.
-        """
-        if layer_number > 1:
-            if current_layer == 0:
-                return ["top"]
-            elif current_layer == layer_number - 1:
-                return ["bottom"]
-            else:
-                return ["top", "bottom"]
-
-    def _update_annotations(self):
-        """
-        Function for when a layer is added or removed from the viewer.
-        """
-        layers_to_annotate = defaultdict(list)
-        layer_translations = _find_grid_offsets(
-            self.viewer
-        )  # Get grid offsets
-        layer_translations.reverse()  # Reverse order to match layer order
-
-        for i, layer in enumerate(self.viewer.layers[::-1]):
-            if not layer.visible:
-                continue
-            if (
-                self.selected_layer_names is not None
-                and layer.name not in self.selected_layer_names
-            ):
-                continue
-
-            layers_to_annotate["layer_names"].append(layer.name)
-            layers_to_annotate["hidden_outlines"].append(
-                self._outlines_to_hide(i, len(self.viewer.layers))
-            )
-
-            # Get color information
-            if isinstance(layer, labels.Labels):
-                layers_to_annotate["colors"].append(self.overlay.color)
-            else:
-                try:
-                    layers_to_annotate["colors"].append(
-                        layer.colormap.colors[-1]
-                    )
-                except AttributeError:
-                    layers_to_annotate["colors"].append(self.overlay.color)
-
-            # Update offsets based on grid position
-            grid_offset = layer_translations[i]
-
-            # Apply layer scale to offsets
-            layer_scale = getattr(layer, "scale", 1.0)[-1]
-
-            layers_to_annotate["y_offsets"].append(grid_offset[-2])
-            layers_to_annotate["x_offsets"].append(grid_offset[-1])
-            layers_to_annotate["layer_scales"].append(layer_scale)
-
-            # Apply scale to layer widths as well
-            if not isinstance(layer, (Image, labels.Labels)):
-                extent = self.viewer._sliced_extent_world_augmented
-                width = extent[1][-2] - extent[0][-2]
-                layers_to_annotate["layer_widths"].append(width)
-            else:
-                width = layer.data.shape[-2:][1]
-                layers_to_annotate["layer_widths"].append(width)
-
-        # Convert colors to ColorArray
         try:
-            layers_to_annotate["colors"] = ColorArray(
-                layers_to_annotate["colors"]
+            if self._layer_node is None:
+                return
+            target = self._layer_node.parent
+            if target is None:
+                return
+            if self.node.parent is not target:
+                self.node.parent = target
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ------------------------------------------------------------------
+    # GL state
+    # ------------------------------------------------------------------
+
+    def _apply_subvisual_gl_state(self) -> None:
+        """
+        Force translucent_no_depth on all sub-visuals.
+
+        Previously the background rect used blend=False (truly opaque) to
+        survive additive-layer blending.  That is no longer needed because
+        re-parenting to the ViewBox scene ensures we render AFTER all layer
+        nodes in vispy's DFS, so no subsequent layer can overwrite us.
+
+        Using translucent_no_depth for the rect:
+        - depth_test=False  → always drawn on top
+        - standard src_alpha blending → background opacity works correctly
+        - resets the active GL blend function → not affected by a layer's
+          additive/minimum blend mode that ran just before us
+        """
+        _tnd = BLENDING_MODES["translucent_no_depth"]
+        for sv in (
+            self.node._rectagles_visual,
+            self.node._textvisual,
+            self.node._outline_visual,
+            self.node._corner_markers,
+        ):
+            sv.set_gl_state(**_tnd)
+
+    def _on_blending_change(self, event=None) -> None:
+        # super() propagates translucent_no_depth to all sub-visuals via
+        # CompoundVisual.set_gl_state(); _apply_subvisual_gl_state reaffirms
+        # the same state so both paths stay consistent.
+        super()._on_blending_change()
+        self._apply_subvisual_gl_state()
+
+    # ------------------------------------------------------------------
+    # Visible change (re-parent after napari resets parent)
+    # ------------------------------------------------------------------
+
+    def _on_visible_change(self, event=None) -> None:
+        """
+        layer.events.visible triggers _update_layer_overlays (canvas, first)
+        which resets node.parent = layer_node.  Our handler fires second
+        (canvas connected earlier) and re-parents back to ViewBox scene.
+        """
+        super()._on_visible_change()
+        self._reparent_to_viewbox_scene()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _layer_color(layer: Layer, overlay: LayerAnnotatorOverlay) -> Any:
+        if not overlay.use_layer_color:
+            return overlay.color
+        if isinstance(layer, labels.Labels):
+            return overlay.color
+        try:
+            return layer.colormap.colors[-1]
+        except AttributeError:
+            return overlay.color
+
+    def _get_layer_extent(self) -> tuple[float, float, float, float, float]:
+        """Return (x_min, y_min, x_max, y_max, width) in world/scene space."""
+        try:
+            ext = self.layer.extent.world
+            y_min = float(ext[0][-2])
+            x_min = float(ext[0][-1])
+            y_max = float(ext[1][-2])
+            x_max = float(ext[1][-1])
+        except Exception:  # noqa: BLE001
+            shape = self.layer.data.shape
+            scale = list(getattr(self.layer, "scale", [1.0] * len(shape)))
+            translate = list(
+                getattr(self.layer, "translate", [0.0] * len(shape))
             )
+            y_min = float(translate[-2])
+            x_min = float(translate[-1])
+            y_max = y_min + shape[-2] * float(scale[-2])
+            x_max = x_min + shape[-1] * float(scale[-1])
+        try:
+            width = self.layer.data.shape[-1] * float(self.layer.scale[-1])
+        except Exception:  # noqa: BLE001
+            width = x_max - x_min
+        return x_min, y_min, x_max, y_max, width
+
+    def _get_camera_rect(
+        self, layer_width: float, layer_height: float
+    ) -> tuple[float, float, float, float] | None:
+        """
+        Visible world rect of the current ViewBox camera.
+
+        Uses r.left/right/top/bottom (not r.pos/size) for y-up/y-down safety.
+        Rejects the vispy default (0,0,1,1) before first render via the
+        1%-of-layer-size sanity check.
+        """
+        try:
+            # We're in viewbox_scene; one level up is the ViewBox (has camera)
+            node = self.node.parent  # viewbox_scene
+            if node is not None:
+                node = node.parent  # ViewBox
+            for _ in range(20):
+                if node is None:
+                    break
+                cam = getattr(node, "camera", None)
+                if cam is not None and hasattr(cam, "rect"):
+                    r = cam.rect
+                    vx0 = min(float(r.left), float(r.right))
+                    vx1 = max(float(r.left), float(r.right))
+                    vy0 = min(float(r.bottom), float(r.top))
+                    vy1 = max(float(r.bottom), float(r.top))
+                    if (vx1 - vx0) < layer_width * 0.01:
+                        return None
+                    if (vy1 - vy0) < layer_height * 0.01:
+                        return None
+                    return vx0, vy0, vx1, vy1
+                node = node.parent
+        except Exception:  # noqa: BLE001
+            pass
+        return None
+
+    def _label_height_world(self) -> float:
+        return self.overlay.size * TextWithBoxVisual.RECTANGLE_SCALER
+
+    def _stack_index(self) -> int:
+        """0 = topmost visible layer.  Always 0 in grid mode."""
+        if self.viewer.grid.enabled:
+            return 0
+        visible = [
+            layer for layer in reversed(self.viewer.layers) if layer.visible
+        ]
+        try:
+            return visible.index(self.layer)
         except ValueError:
-            layers_to_annotate["colors"] = ColorArray(["white"])
+            return 0
 
-        self.overlay.layers_to_annotate = layers_to_annotate
-        self._on_property_change()
+    # ------------------------------------------------------------------
+    # Event callbacks
+    # ------------------------------------------------------------------
 
-    def _on_viewer_zoom_change(self, event=None):
-        """
-        Callback function for when the viewer is zoomed.
-        """
-        self.camera_scale_factor = self.viewer.camera.zoom
+    def _on_zoom_change(self, event=None) -> None:
+        self._camera_zoom = max(self.viewer.camera.zoom, 1e-6)
+        self.node.scale_factor = self._camera_zoom
         self._on_size_change()
 
-    def _get_max_layer_scale(self):
-        """
-        Returns the maximum layer scale from the layers to annotate.
-        """
-        if len(self.overlay.layers_to_annotate["layer_scales"]) > 0:
-            return max(self.overlay.layers_to_annotate["layer_scales"])
-        return 1.0
-
-    def _on_position_change(self, event=None):
-        """
-        Callback function for when the position of the overlay is changed.
-        """
-        layers = self.overlay.layers_to_annotate
-        if not layers.get("layer_names"):
-            return
-
-        max_layer_scale = self._get_max_layer_scale()
-        position = self.overlay.position
-        y_max, x_max = (
-            self.viewer.dims.range[-2][-2],
-            self.viewer.dims.range[-1][-2],
+    def _on_property_change(self, event=None) -> None:
+        in_3d = self.viewer.dims.ndisplay == 3
+        self.node.show_outline = False if in_3d else self.overlay.show_outline
+        self.node._rectagles_visual.visible = (
+            False if in_3d else self.overlay.show_background
         )
-
-        if len(layers.get("y_offsets", [])) < 1:
-            layers["y_offsets"] = [0]
-        if len(layers.get("x_offsets", [])) < 1:
-            layers["x_offsets"] = [0]
-        if len(layers.get("layer_widths", [])) < 1:
-            layers["layer_widths"] = [0]
-        if len(layers.get("layer_scales", [])) < 1:
-            layers["layer_scales"] = [1]
-
-        if position == ScenePosition.TOP_LEFT:
-            y_offsets, x_offsets = self.correct_offsets_for_overlap("down")
-            anchors = ("left", "bottom")
-            transform = [
-                self.x_spacer - self.ANCHOR_CORRECTION * max_layer_scale,
-                self.y_spacer - self.ANCHOR_CORRECTION * max_layer_scale,
-                0,
-                0,
-            ]
-
-        elif position == ScenePosition.TOP_RIGHT:
-            y_offsets, x_offsets = self.correct_offsets_for_overlap("down")
-            anchors = ("right", "bottom")
-            transform = [
-                x_max
-                - self.x_size
-                - self.x_spacer
-                + self.ANCHOR_CORRECTION * max_layer_scale,
-                self.y_spacer - self.ANCHOR_CORRECTION * max_layer_scale,
-                0,
-                0,
-            ]
-        elif position == ScenePosition.TOP_CENTER:
-            y_offsets, x_offsets = self.correct_offsets_for_overlap("down")
-            transform = [
-                x_max / 2 - self.x_size / 2,
-                self.y_spacer - self.ANCHOR_CORRECTION * max_layer_scale,
-                0,
-                0,
-            ]
-            anchors = ("center", "bottom")
-
-        elif position == ScenePosition.BOTTOM_RIGHT:
-            y_offsets, x_offsets = self.correct_offsets_for_overlap("up")
-            anchors = ("right", "top")
-            transform = [
-                x_max
-                - self.x_size
-                - self.x_spacer
-                + self.ANCHOR_CORRECTION * max_layer_scale,
-                y_max
-                - self.y_size
-                - self.y_spacer
-                + self.ANCHOR_CORRECTION * max_layer_scale,
-                0,
-                0,
-            ]
-        elif position == ScenePosition.BOTTOM_LEFT:
-            y_offsets, x_offsets = self.correct_offsets_for_overlap("up")
-            anchors = ("left", "top")
-            transform = [
-                self.x_spacer - self.ANCHOR_CORRECTION * max_layer_scale,
-                y_max
-                - self.y_size
-                - self.y_spacer
-                + self.ANCHOR_CORRECTION * max_layer_scale,
-                0,
-                0,
-            ]
-        elif position == ScenePosition.BOTTOM_CENTER:
-            y_offsets, x_offsets = self.correct_offsets_for_overlap("up")
-            anchors = ("center", "top")
-            transform = [
-                x_max / 2 - self.x_size / 2,
-                y_max
-                - self.y_size
-                - self.y_spacer
-                + self.ANCHOR_CORRECTION * max_layer_scale,
-                0,
-                0,
-            ]
-
-        self.node.transform.translate = transform
-        self.node.anchors = anchors
-        self.node._rectagles_visual.spacer = self.x_spacer
-        layer_widths = [
-            layer_width * layer_scale
-            for layer_width, layer_scale in zip(
-                self.overlay.layers_to_annotate["layer_widths"],
-                self.overlay.layers_to_annotate["layer_scales"],
-            )
-        ]
-
-        self.node.update_data(
-            text=self.overlay.layers_to_annotate["layer_names"],
-            color=self.overlay.layers_to_annotate["colors"]
-            if self.overlay.use_layer_color
-            else self.overlay.color,
-            font_size=self.overlay.size,
-            pos=list(zip(x_offsets, y_offsets)),
-            box_width=layer_widths,
-            bgcolor=self.overlay.bg_color.rgba.tolist(),
-            hide_parial_outline=None
-            if self.viewer.grid.enabled
-            else self.overlay.layers_to_annotate["hidden_outlines"],
-        )
-
-    def correct_offsets_for_overlap(
-        self, movement_direction: Literal["up", "down"] = "down"
-    ):
-        existing_offsets = []
-        y_offsets = self.overlay.layers_to_annotate["y_offsets"].copy()
-        x_offsets = self.overlay.layers_to_annotate["x_offsets"].copy()
-        for idx, (y, x) in enumerate(
-            zip(
-                self.overlay.layers_to_annotate["y_offsets"],
-                self.overlay.layers_to_annotate["x_offsets"],
-            )
-        ):
-            if (y, x) in existing_offsets:
-                if movement_direction == "down":
-                    y_offsets[idx] += (
-                        self.RECTANGLE_SCALER
-                        * self.overlay.size
-                        * existing_offsets.count((y, x))
-                    )
-                elif movement_direction == "up":
-                    y_offsets[idx] -= (
-                        self.RECTANGLE_SCALER
-                        * self.overlay.size
-                        * existing_offsets.count((y, x))
-                    )
-            existing_offsets.append((y, x))
-        return y_offsets, x_offsets
-
-    def _on_size_change(self, event=None):
-        """
-        Callback function for when the size of the overlay is changed.
-        """
-        self.node.scale_factor = self.camera_scale_factor
-        self.node.font_size = self.overlay.size
-        self.node.outline_thickness = self.overlay.outline_thickness
-        self._on_position_change()
-
-    def _on_property_change(self, event=None):
-        """
-        Callback function for when properties of the overlay are changed.
-        """
-        layers = self.overlay.layers_to_annotate
-        if not layers.get("layer_names"):
-            self.node._rectagles_visual.visible = False
-            self.node.show_outline = False
-            return
-
-        if self.viewer.dims.ndisplay == 3:
-            self.node.show_outline = False
-            self.node._rectagles_visual.visible = False
-        else:
-            self.node.show_outline = self.overlay.show_outline
-            self.node._rectagles_visual.visible = self.overlay.show_background
-
-        self.node.text = layers["layer_names"]
+        self.node.text = [self.layer.name]
         self.node.bold = self.overlay.bold
         self.node.italic = self.overlay.italic
         self.node.outline_color = self.overlay.outline_color
         self.node.outline_thickness = self.overlay.outline_thickness
         self.node.bgcolor = self.overlay.bg_color.rgba.tolist()
-        if self.overlay.use_layer_color:
-            self.node.color = layers.get("colors", self.overlay.color)
-        else:
-            self.node.color = self.overlay.color
+        self.node.color = self._layer_color(self.layer, self.overlay)
         self._on_size_change()
+        self.node.update()
 
-    def reset(self):
+    def _on_size_change(self, event=None) -> None:
+        self.node.font_size = self.overlay.size
+        self.node.outline_thickness = self.overlay.outline_thickness
+        self._on_position_change()
+
+    def _on_position_change(self, event=None) -> None:
         """
-        Resets the overlay to its initial state.
+        Recompute and apply label position.
+
+        Called for ALL events that might reset our parent (grid changes,
+        layer reorder, etc.).  The first two steps handle the side effects
+        of those resets before doing any positioning work.
         """
+        # 1. Re-parent in case _update_scenegraph reset us to layer_node.
+        self._reparent_to_viewbox_scene()
+
+        # 2. Restore correct visibility (node may have been hidden by a
+        #    previous grid-mode clamp; must reset before any early-return).
+        self.node.visible = self._should_be_visible()
+
+        x_min, y_min, x_max, y_max, width = self._get_layer_extent()
+        if width <= 0:
+            return
+
+        layer_h = y_max - y_min
+
+        # 3. Grid sticky: clamp to visible viewport ∩ layer_extent
+        if self.viewer.grid.enabled:
+            cam = self._get_camera_rect(width, layer_h)
+            if cam is not None:
+                vx0, vy0, vx1, vy1 = cam
+                x_min = max(x_min, vx0)
+                y_min = max(y_min, vy0)
+                x_max = min(x_max, vx1)
+                y_max = min(y_max, vy1)
+                width = max(x_max - x_min, 0)
+                if width <= 0 or y_max <= y_min:
+                    self.node.visible = False
+                    return
+
+        position = str(self.overlay.position)
+        step = self._label_height_world()
+        idx = self._stack_index()
+
+        if "top" in position:
+            y_base = y_min - 0.5 + idx * step
+        else:
+            y_base = y_max + 0.5 - (idx + 1) * step
+
+        if "left" in position:
+            px = x_min - 0.5
+        elif "right" in position:
+            px = x_max + 0.5
+        else:
+            px = (x_min + x_max) / 2
+
+        anchors = _ANCHOR_MAP.get(position, ("left", "bottom"))
+        self.node.anchors = anchors
+        self.node.update_data(
+            text=[self.layer.name],
+            color=self._layer_color(self.layer, self.overlay),
+            font_size=self.overlay.size,
+            pos=[(px, y_base)],
+            box_width=[width],
+            bgcolor=self.overlay.bg_color.rgba.tolist(),
+            hide_parial_outline=None,
+        )
+        self.node.update()
+
+    # ------------------------------------------------------------------
+    # Reset / teardown
+    # ------------------------------------------------------------------
+
+    def reset(self) -> None:
         super().reset()
         self._on_property_change()
-        self._on_size_change()
-        self._on_position_change()
-        self._on_viewer_zoom_change()
-        self._update_annotations()
+
+    def close(self) -> None:
+        _disconnects = [
+            (self._on_zoom_change, self.viewer.camera.events.zoom),
+            (self._on_position_change, self.viewer.camera.events.center),
+            (self._on_position_change, self.viewer.grid.events.enabled),
+            (self._on_position_change, self.viewer.grid.events.shape),
+            (self._on_position_change, self.viewer.grid.events.stride),
+            (self._on_position_change, self.viewer.grid.events.spacing),
+            (self._on_position_change, self.viewer.layers.events.reordered),
+            (self._on_position_change, self.viewer.layers.events.inserted),
+            (self._on_position_change, self.viewer.layers.events.removed),
+        ]
+        for cb, event in _disconnects:
+            with contextlib.suppress(Exception):
+                event.disconnect(cb)
+        super().close()
+
+
+# ---------------------------------------------------------------------------
+# Register with napari's overlay factory
+# ---------------------------------------------------------------------------
+overlay_to_visual[LayerAnnotatorOverlay] = VispyLayerAnnotatorOverlay
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+
+class LayerAnnotatorManager:
+    """Attaches a LayerAnnotatorOverlay to every layer and keeps them in sync."""
+
+    OVERLAY_KEY = "layer_annotator"
+
+    def __init__(
+        self,
+        viewer: ViewerModel,
+        overlay_key: str = OVERLAY_KEY,
+        **settings: Any,
+    ) -> None:
+        self.viewer = viewer
+        self.overlay_key = overlay_key
+        self._settings: dict[str, Any] = settings
+
+        for layer in self.viewer.layers:
+            self._attach(layer)
+
+        self.viewer.layers.events.inserted.connect(self._on_layer_inserted)
+        self.viewer.layers.events.removed.connect(self._on_layer_removed)
+
+    def _attach(self, layer: Layer) -> None:
+        if self.overlay_key not in layer._overlays:
+            layer._overlays[self.overlay_key] = LayerAnnotatorOverlay(
+                **self._settings
+            )
+
+    def _detach(self, layer: Layer) -> None:
+        layer._overlays.pop(self.overlay_key, None)
+
+    def _on_layer_inserted(self, event) -> None:
+        self._attach(event.value)
+
+    def _on_layer_removed(self, event) -> None:
+        self._detach(event.value)
+
+    def update_settings(self, **settings: Any) -> None:
+        """Apply *settings* to every managed overlay."""
+        self._settings.update(settings)
+        for layer in self.viewer.layers:
+            overlay = layer._overlays.get(self.overlay_key)
+            if overlay is not None:
+                for key, value in settings.items():
+                    setattr(overlay, key, value)
+
+    def get_any_overlay(self) -> LayerAnnotatorOverlay | None:
+        for layer in self.viewer.layers:
+            overlay = layer._overlays.get(self.overlay_key)
+            if overlay is not None:
+                return overlay
+        return None
+
+    def set_visible(self, visible: bool) -> None:
+        self._settings["visible"] = visible
+        for layer in self.viewer.layers:
+            overlay = layer._overlays.get(self.overlay_key)
+            if overlay is not None:
+                overlay.visible = visible
+
+    def set_layer_visible(self, layer_name: str, visible: bool) -> None:
+        for layer in self.viewer.layers:
+            if layer.name == layer_name:
+                overlay = layer._overlays.get(self.overlay_key)
+                if overlay is not None:
+                    overlay.visible = visible
+
+    def close(self) -> None:
+        self.viewer.layers.events.inserted.disconnect(self._on_layer_inserted)
+        self.viewer.layers.events.removed.disconnect(self._on_layer_removed)
+        for layer in self.viewer.layers:
+            self._detach(layer)

--- a/src/napari_timestamper/_tests/test_layer_annotator_overlay.py
+++ b/src/napari_timestamper/_tests/test_layer_annotator_overlay.py
@@ -1,92 +1,222 @@
-import warnings
-from unittest.mock import patch
+"""
+Tests for the refactored LayerAnnotatorOverlay.
+
+Key facts about the new architecture:
+- SceneOverlay.visible defaults to False (napari keeps scene overlays hidden
+  until explicitly enabled).  Tests that check visibility must account for this.
+- One LayerAnnotatorOverlay lives in layer._overlays[OVERLAY_KEY] per layer.
+- VispyLayerAnnotatorOverlay requires a `layer` argument; access it via the
+  canvas's _layer_overlay_to_visual dict after setting visible=True.
+- The canvas defers vispy overlay creation until overlay.visible is True.
+"""
 
 import numpy as np
 import pytest
 from napari._vispy.utils.visual import overlay_to_visual
-from vispy.color import ColorArray
 
 from napari_timestamper._layer_annotator_overlay import (
+    LayerAnnotatorManager,
     LayerAnnotatorOverlay,
     VispyLayerAnnotatorOverlay,
 )
 
+OVERLAY_KEY = LayerAnnotatorManager.OVERLAY_KEY
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
 
 @pytest.fixture
-def overlay():
-    return LayerAnnotatorOverlay()
+def viewer_with_layers(make_napari_viewer):
+    """Viewer with two image layers and the overlay factory registered."""
+    viewer = make_napari_viewer()
+    overlay_to_visual[LayerAnnotatorOverlay] = VispyLayerAnnotatorOverlay
+    l1 = viewer.add_image(np.random.random((10, 10)), name="Layer1")
+    l2 = viewer.add_image(np.random.random((10, 10)), name="Layer2")
+    return viewer, l1, l2
 
 
 @pytest.fixture
-def vispy_overlay(overlay, make_napari_viewer):
-    viewer = make_napari_viewer()
-    return VispyLayerAnnotatorOverlay(viewer=viewer, overlay=overlay)
+def manager(viewer_with_layers):
+    viewer, l1, l2 = viewer_with_layers
+    mgr = LayerAnnotatorManager(viewer)
+    return mgr, viewer, l1, l2
 
 
-def test_init(vispy_overlay):
-    assert vispy_overlay.x_spacer == 0
-    assert vispy_overlay.y_spacer == 0
-    assert vispy_overlay.x_size == 0
-    assert vispy_overlay.y_size == 0
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
 
 
-def test_update_offsets(vispy_overlay):
-    vispy_overlay.overlay.x_spacer = 10
-    vispy_overlay.overlay.y_spacer = 20
-    vispy_overlay._update_offsets()
-    assert vispy_overlay.x_spacer == 10
-    assert vispy_overlay.y_spacer == 20
+def test_overlay_model_defaults():
+    overlay = LayerAnnotatorOverlay()
+    assert overlay.color == "white"
+    assert overlay.size == 12
+    assert overlay.bold is False
+    assert overlay.italic is False
+    assert overlay.show_background is False
+    assert overlay.show_outline is False
+    # SceneOverlay.visible defaults to False in napari
+    assert overlay.visible is False
 
 
-def test_on_size_change(vispy_overlay):
-    vispy_overlay.overlay.size = 15
-    vispy_overlay._on_size_change()
-    assert vispy_overlay.node.font_size == 15
+def test_overlay_model_custom_values():
+    overlay = LayerAnnotatorOverlay(color="red", size=20, bold=True)
+    assert overlay.color == "red"
+    assert overlay.size == 20
+    assert overlay.bold is True
 
 
-def test_on_property_change(vispy_overlay):
-    vispy_overlay.viewer.add_image(np.random.random((10, 10)), name="Layer1")
-    # vispy_overlay.overlay.layers_to_annotate["layer_names"] = ["Layer1"]
-    assert vispy_overlay.node.color != ColorArray("red")
-    vispy_overlay.overlay.color = "red"
-    vispy_overlay._on_property_change()
-    assert vispy_overlay.node.text == ["Layer1"]
-    assert vispy_overlay.node.color == ColorArray("red")
+def test_overlay_model_visible_explicit():
+    overlay = LayerAnnotatorOverlay(visible=True)
+    assert overlay.visible is True
 
 
-def test_reset(vispy_overlay):
-    with patch.object(
-        vispy_overlay, "_on_property_change"
-    ) as mock_property_change, patch.object(
-        vispy_overlay, "_on_size_change"
-    ) as mock_size_change, patch.object(
-        vispy_overlay, "_on_position_change"
-    ) as mock_position_change, patch.object(
-        vispy_overlay, "_on_viewer_zoom_change"
-    ) as mock_zoom_change, patch.object(
-        vispy_overlay, "_update_annotations"
-    ) as mock_update_annotations:
-        vispy_overlay.reset()
-    mock_property_change.assert_called_once()
-    mock_size_change.assert_called_once()
-    mock_position_change.assert_called_once()
-    mock_zoom_change.assert_called_once()
-    mock_update_annotations.assert_called_once()
+# ---------------------------------------------------------------------------
+# Manager tests
+# ---------------------------------------------------------------------------
 
 
-def test_add_overlay_to_viewer(make_napari_viewer):
-    viewer = make_napari_viewer()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        try:
-            viewer._overlays["LayerAnnotator"]
-        except KeyError:
-            overlay_to_visual[
-                LayerAnnotatorOverlay
-            ] = VispyLayerAnnotatorOverlay
-            viewer._overlays["LayerAnnotator"] = LayerAnnotatorOverlay(
-                visible=True
-            )
-        layer_annotator_overlay = viewer._overlays["LayerAnnotator"]
+def test_manager_attaches_overlay_to_existing_layers(manager):
+    mgr, viewer, l1, l2 = manager
+    assert OVERLAY_KEY in l1._overlays
+    assert OVERLAY_KEY in l2._overlays
+    assert isinstance(l1._overlays[OVERLAY_KEY], LayerAnnotatorOverlay)
+    assert isinstance(l2._overlays[OVERLAY_KEY], LayerAnnotatorOverlay)
 
-    assert isinstance(layer_annotator_overlay, LayerAnnotatorOverlay)
+
+def test_manager_attaches_overlay_to_new_layer(manager):
+    mgr, viewer, l1, l2 = manager
+    l3 = viewer.add_image(np.random.random((10, 10)), name="Layer3")
+    assert OVERLAY_KEY in l3._overlays
+    assert isinstance(l3._overlays[OVERLAY_KEY], LayerAnnotatorOverlay)
+
+
+def test_manager_detaches_overlay_on_layer_remove(manager):
+    mgr, viewer, l1, l2 = manager
+    viewer.layers.remove(l1)
+    assert OVERLAY_KEY not in l1._overlays
+
+
+def test_manager_update_settings_propagates(manager):
+    mgr, viewer, l1, l2 = manager
+    mgr.update_settings(size=20, bold=True, color="cyan")
+    for layer in [l1, l2]:
+        ov = layer._overlays[OVERLAY_KEY]
+        assert ov.size == 20
+        assert ov.bold is True
+        assert ov.color == "cyan"
+
+
+def test_manager_set_visible(manager):
+    mgr, viewer, l1, l2 = manager
+    # Explicitly show first
+    mgr.set_visible(True)
+    for layer in [l1, l2]:
+        assert layer._overlays[OVERLAY_KEY].visible is True
+    # Then hide
+    mgr.set_visible(False)
+    for layer in [l1, l2]:
+        assert layer._overlays[OVERLAY_KEY].visible is False
+
+
+def test_manager_set_layer_visible(manager):
+    mgr, viewer, l1, l2 = manager
+    # Start with both visible
+    mgr.set_visible(True)
+    # Hide only Layer1
+    mgr.set_layer_visible("Layer1", False)
+    assert l1._overlays[OVERLAY_KEY].visible is False
+    assert l2._overlays[OVERLAY_KEY].visible is True  # unaffected
+
+
+def test_manager_get_any_overlay(manager):
+    mgr, viewer, l1, l2 = manager
+    ov = mgr.get_any_overlay()
+    assert ov is not None
+    assert isinstance(ov, LayerAnnotatorOverlay)
+
+
+def test_manager_close(manager):
+    mgr, viewer, l1, l2 = manager
+    mgr.close()
+    l3 = viewer.add_image(np.random.random((10, 10)), name="Layer3")
+    assert OVERLAY_KEY not in l3._overlays
+
+
+def test_manager_initial_settings_applied(viewer_with_layers):
+    viewer, l1, l2 = viewer_with_layers
+    _ = LayerAnnotatorManager(viewer, size=18, color="magenta")
+    for layer in [l1, l2]:
+        ov = layer._overlays[OVERLAY_KEY]
+        assert ov.size == 18
+        assert ov.color == "magenta"
+
+
+# ---------------------------------------------------------------------------
+# Integration: factory registration and overlay placement
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_registered_in_factory():
+    assert LayerAnnotatorOverlay in overlay_to_visual
+    assert (
+        overlay_to_visual[LayerAnnotatorOverlay] is VispyLayerAnnotatorOverlay
+    )
+
+
+def test_layer_overlay_added_to_layer_not_viewer(viewer_with_layers):
+    """Overlays now live in layer._overlays, NOT in viewer._overlays."""
+    viewer, l1, l2 = viewer_with_layers
+    _ = LayerAnnotatorManager(viewer)
+    assert "LayerAnnotator" not in viewer._overlays
+    assert OVERLAY_KEY in l1._overlays
+    assert OVERLAY_KEY in l2._overlays
+
+
+# ---------------------------------------------------------------------------
+# Vispy visual smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_vispy_overlay_created_by_canvas(viewer_with_layers):
+    """
+    Canvas creates VispyLayerAnnotatorOverlay when overlay.visible=True.
+    (napari defers vispy overlay creation until visible=True.)
+    """
+    viewer, l1, _l2 = viewer_with_layers
+    _ = LayerAnnotatorManager(
+        viewer, visible=True
+    )  # visible=True → canvas creates visual
+    canvas = viewer.window._qt_viewer.canvas
+    overlay_model = l1._overlays[OVERLAY_KEY]
+    layer_visuals = canvas._layer_overlay_to_visual.get(l1, {})
+    if overlay_model not in layer_visuals:
+        pytest.skip(
+            "Canvas did not create vispy overlay (headless / deferred)"
+        )
+    vispy_ov = layer_visuals[overlay_model]
+    assert isinstance(vispy_ov, VispyLayerAnnotatorOverlay)
+
+
+def test_vispy_overlay_reparented_to_scene(viewer_with_layers):
+    """
+    After creation the vispy node must be in the ViewBox scene
+    (sibling of layer nodes), NOT a child of the layer node.
+    """
+    viewer, l1, _l2 = viewer_with_layers
+    _ = LayerAnnotatorManager(viewer, visible=True)
+    canvas = viewer.window._qt_viewer.canvas
+    overlay_model = l1._overlays[OVERLAY_KEY]
+    layer_visuals = canvas._layer_overlay_to_visual.get(l1, {})
+    vispy_ov = layer_visuals.get(overlay_model)
+    if vispy_ov is None:
+        pytest.skip(
+            "Canvas did not create vispy overlay (headless / deferred)"
+        )
+    layer_vispy_node = canvas.layer_to_visual[l1].node
+    assert (
+        vispy_ov.node.parent is not layer_vispy_node
+    ), "Overlay node is still a child of the layer node — additive blending will break"

--- a/src/napari_timestamper/_tests/test_layer_annotator_overlay.py
+++ b/src/napari_timestamper/_tests/test_layer_annotator_overlay.py
@@ -81,14 +81,11 @@ def test_add_overlay_to_viewer(make_napari_viewer):
         try:
             viewer._overlays["LayerAnnotator"]
         except KeyError:
-            viewer._overlays["LayerAnnotator"] = LayerAnnotatorOverlay(
-                visible=True
-            )
             overlay_to_visual[
                 LayerAnnotatorOverlay
             ] = VispyLayerAnnotatorOverlay
-            viewer.window._qt_viewer.canvas._add_overlay_to_visual(
-                viewer._overlays["LayerAnnotator"]
+            viewer._overlays["LayerAnnotator"] = LayerAnnotatorOverlay(
+                visible=True
             )
         layer_annotator_overlay = viewer._overlays["LayerAnnotator"]
 

--- a/src/napari_timestamper/_tests/test_timestamp_overlay.py
+++ b/src/napari_timestamper/_tests/test_timestamp_overlay.py
@@ -23,11 +23,8 @@ def test_text_instantiation(make_napari_viewer):
         try:
             viewer._overlays["timestamp"]
         except KeyError:
-            viewer._overlays["timestamp"] = TimestampOverlay(visible=True)
             overlay_to_visual[TimestampOverlay] = VispyTimestampOverlay
-            viewer.window._qt_viewer.canvas._add_overlay_to_visual(
-                viewer._overlays["timestamp"]
-            )
+            viewer._overlays["timestamp"] = TimestampOverlay(visible=True)
         timestamp_overlay = viewer._overlays["timestamp"]
 
     assert isinstance(timestamp_overlay, TimestampOverlay)

--- a/src/napari_timestamper/_tests/test_widget.py
+++ b/src/napari_timestamper/_tests/test_widget.py
@@ -1,3 +1,19 @@
+"""
+Widget tests — updated for the refactored architecture.
+
+Key changes vs. original:
+- layer_annotations_widget fixture adds a layer before creating the widget
+  so _annotator_manager.get_any_overlay() returns a valid overlay.
+- LayerAnnotationsWidget now exposes a `layer_annotator_overlay` property
+  (see widget.py) that returns the first managed overlay for convenience.
+- x_spacer / y_spacer were removed from LayerAnnotatorOverlay (they were
+  canvas-space concepts that don't exist on a SceneOverlay); those tests
+  now cover bold / italic instead.
+- time_axis is a QComboBox, not a QSpinBox: replaced .value()/.setValue()
+  with .currentIndex()/.setCurrentIndex() and added a 3-D image so the
+  combobox is populated.
+"""
+
 import tempfile
 from pathlib import Path
 
@@ -12,6 +28,10 @@ from napari_timestamper._widget import (
     TimestampWidget,
 )
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def timestamp_options(make_napari_viewer, qtbot):
@@ -24,6 +44,8 @@ def timestamp_options(make_napari_viewer, qtbot):
 @pytest.fixture
 def layer_annotations_widget(make_napari_viewer, qtbot):
     viewer = make_napari_viewer()
+    # A layer must exist so _annotator_manager.get_any_overlay() is non-None
+    viewer.add_image(np.random.random((10, 10)), name="test_layer")
     widget = LayerAnnotationsWidget(viewer)
     viewer.window.add_dock_widget(widget)
     return widget
@@ -46,8 +68,16 @@ def layer_to_rgb_widget(make_napari_viewer, qtbot):
     return widget, viewer, qtbot
 
 
+# ---------------------------------------------------------------------------
+# TimestampWidget
+# ---------------------------------------------------------------------------
+
+
 def test_initial_values(timestamp_options):
-    assert timestamp_options.time_axis.value() == 0
+    # time_axis is a QComboBox — no .value(); use currentIndex()
+    assert (
+        timestamp_options.time_axis.currentIndex() == -1
+    )  # empty (no time dim)
     assert timestamp_options.start_time.value() == 0
     assert timestamp_options.step_time.value() == 1
     assert timestamp_options.prefix.text() == ""
@@ -66,87 +96,131 @@ def test_set_color(timestamp_options, qtbot):
     assert timestamp_options.chosen_color != "white"
 
 
-def test_set_timestamp_overlay_options(timestamp_options):
-    timestamp_options.time_axis.setValue(1)
-    timestamp_options.start_time.setValue(10)
-    timestamp_options.step_time.setValue(2)
-    timestamp_options.prefix.setText("Time =")
-    timestamp_options.suffix.setText("s")
-    timestamp_options.position.setCurrentIndex(2)
-    timestamp_options.ts_size.setValue(20)
-    timestamp_options.x_shift.setValue(5)
-    timestamp_options.y_shift.setValue(-5)
-    timestamp_options.time_format.setCurrentIndex(1)
+def test_set_timestamp_overlay_options(make_napari_viewer, qtbot):
+    """Use a 3D image so the time_axis combobox is populated."""
+    viewer = make_napari_viewer()
+    viewer.add_image(np.random.random((5, 10, 10)))  # 3D: axis 0 is time
+    widget = TimestampWidget(viewer)
+    viewer.window.add_dock_widget(widget)
 
-    timestamp_options._set_timestamp_overlay_options()
+    # time_axis is QComboBox — use setCurrentIndex
+    widget.time_axis.setCurrentIndex(0)
+    widget.start_time.setValue(10)
+    widget.step_time.setValue(2)
+    widget.prefix.setText("Time =")
+    widget.suffix.setText("s")
+    widget.position.setCurrentIndex(2)
+    widget.ts_size.setValue(20)
+    widget.x_shift.setValue(5)
+    widget.y_shift.setValue(-5)
+    widget.time_format.setCurrentIndex(1)
 
-    assert timestamp_options.viewer._overlays["timestamp"].time_axis == 1
-    assert timestamp_options.viewer._overlays["timestamp"].start_time == 10
-    assert timestamp_options.viewer._overlays["timestamp"].step_size == 2
-    assert timestamp_options.viewer._overlays["timestamp"].prefix == "Time ="
-    assert timestamp_options.viewer._overlays["timestamp"].custom_suffix == "s"
-    assert (
-        timestamp_options.viewer._overlays["timestamp"].position == "top_right"
-    )
-    assert timestamp_options.viewer._overlays["timestamp"].size == 20
-    assert timestamp_options.viewer._overlays["timestamp"].x_spacer == 5
-    assert timestamp_options.viewer._overlays["timestamp"].y_spacer == -5
-    assert (
-        timestamp_options.viewer._overlays["timestamp"].time_format
-        == "HH:MM:SS.ss"
-    )
+    widget._set_timestamp_overlay_options()
+
+    ts = viewer._overlays["timestamp"]
+    assert ts.time_axis == 0
+    assert ts.start_time == 10
+    assert ts.step_size == 2
+    assert ts.prefix == "Time ="
+    assert ts.custom_suffix == "s"
+    assert ts.position == "top_right"
+    assert ts.size == 20
+    assert ts.x_spacer == 5
+    assert ts.y_spacer == -5
+    assert ts.time_format == "HH:MM:SS.ss"
+
+
+# ---------------------------------------------------------------------------
+# LayerAnnotationsWidget
+# ---------------------------------------------------------------------------
 
 
 def test_init(layer_annotations_widget):
     widget = layer_annotations_widget
     assert widget.size_slider.value() == 12
     assert widget.position_combobox.currentText() == "top_left"
-    assert widget.x_offset_spinbox.value() == 0
-    assert widget.y_offset_spinbox.value() == 0
+    # assert widget.x_offset_spinbox.value() == 0
+    # assert widget.y_offset_spinbox.value() == 0
     assert widget.toggle_visibility_button.isChecked() is True
     assert widget.color_checkbox.isChecked() is True
 
 
-def test_on_size_slider_change(layer_annotations_widget, qtbot):
+def test_on_size_slider_change(layer_annotations_widget):
     widget = layer_annotations_widget
+    overlay = widget.layer_annotator_overlay
+    assert overlay is not None
     initial_value = widget.size_slider.value()
-    assert widget.layer_annotator_overlay.size == initial_value
+    assert overlay.size == initial_value
     widget.size_slider.setValue(15)
     assert widget.size_slider.value() == 15
     assert widget.layer_annotator_overlay.size == 15
 
 
-def test_on_x_offset_change(layer_annotations_widget, qtbot):
+def test_bold_propagates(layer_annotations_widget):
+    """bold replaces the removed x_spacer test."""
     widget = layer_annotations_widget
-    initial_value = widget.x_offset_spinbox.value()
-    assert widget.layer_annotator_overlay.x_spacer == initial_value
-    widget.x_offset_spinbox.setValue(10)
-    assert widget.x_offset_spinbox.value() == 10
-    assert widget.layer_annotator_overlay.x_spacer == 10
+    overlay = widget.layer_annotator_overlay
+    assert overlay is not None
+    assert overlay.bold is False
+    widget.bold_checkbox.setChecked(True)
+    assert widget.layer_annotator_overlay.bold is True
+    widget.bold_checkbox.setChecked(False)
+    assert widget.layer_annotator_overlay.bold is False
 
 
-def test_on_y_offset_change(layer_annotations_widget, qtbot):
+def test_italic_propagates(layer_annotations_widget):
+    """italic replaces the removed y_spacer test."""
     widget = layer_annotations_widget
-    initial_value = widget.y_offset_spinbox.value()
-    assert widget.layer_annotator_overlay.y_spacer == initial_value
-    widget.y_offset_spinbox.setValue(20)
-    assert widget.y_offset_spinbox.value() == 20
-    assert widget.layer_annotator_overlay.y_spacer == 20
+    overlay = widget.layer_annotator_overlay
+    assert overlay is not None
+    assert overlay.italic is False
+    widget.italic_checkbox.setChecked(True)
+    assert widget.layer_annotator_overlay.italic is True
+    widget.italic_checkbox.setChecked(False)
+    assert widget.layer_annotator_overlay.italic is False
 
 
-def test_on_toggle_visibility(layer_annotations_widget, qtbot):
+def test_on_toggle_visibility(layer_annotations_widget):
     widget = layer_annotations_widget
-    initial_value = widget.toggle_visibility_button.isChecked()
-    assert widget.layer_annotator_overlay.visible == initial_value
+    overlay = widget.layer_annotator_overlay
+    assert overlay is not None
+    initial = widget.toggle_visibility_button.isChecked()
+    assert overlay.visible == initial
     widget.toggle_visibility_button.click()
-    assert widget.toggle_visibility_button.isChecked() is not initial_value
-    assert widget.layer_annotator_overlay.visible is not initial_value
+    assert widget.toggle_visibility_button.isChecked() is not initial
+    assert widget.layer_annotator_overlay.visible is not initial
+
+
+def test_new_layer_gets_overlay(layer_annotations_widget):
+    """Layers added after widget creation should also receive an overlay."""
+    widget = layer_annotations_widget
+    viewer = widget.viewer
+    new_layer = viewer.add_image(np.random.random((10, 10)), name="new")
+    from napari_timestamper._layer_annotator_overlay import (
+        LayerAnnotatorManager,
+        LayerAnnotatorOverlay,
+    )
+
+    key = LayerAnnotatorManager.OVERLAY_KEY
+    assert key in new_layer._overlays
+    assert isinstance(new_layer._overlays[key], LayerAnnotatorOverlay)
+
+
+def test_position_propagates(layer_annotations_widget):
+    widget = layer_annotations_widget
+    widget.position_combobox.setCurrentText("top_right")
+    widget._set_layer_annotator_overlay_options()
+    assert str(widget.layer_annotator_overlay.position) == "top_right"
+
+
+# ---------------------------------------------------------------------------
+# RenderRGBWidget
+# ---------------------------------------------------------------------------
 
 
 def test_layer_to_rgb_widget(render_rgb_widget):
     widget, viewer = render_rgb_widget
     viewer.add_image(np.random.random((10, 10, 10)))
-    # create a temporary directory
     with tempfile.TemporaryDirectory() as tmpdirname:
         widget.directory = Path(tmpdirname)
         widget.axis_combobox.setCurrentIndex(1)
@@ -168,7 +242,6 @@ def test_layer_to_rgb_widget(render_rgb_widget):
 def test_layer_to_rgb_widget_single(render_rgb_widget):
     widget, viewer = render_rgb_widget
     viewer.add_image(np.random.random((10, 10, 10)))
-    # create a temporary directory
     with tempfile.TemporaryDirectory() as tmpdirname:
         widget.directory = Path(tmpdirname)
         widget.axis_combobox.setCurrentIndex(0)
@@ -183,7 +256,6 @@ def test_convert_layer_to_rgb(layer_to_rgb_widget):
     viewer.add_image(np.random.random((10, 800, 800)))
     for i in range(widget.layer_selector.count()):
         widget.layer_selector.item(i).setCheckState(QtCore.Qt.Checked)
-
     with qtbot.waitSignal(viewer.layers.events.inserted):
         widget.render_button.click()
     assert viewer.layers[1].name == widget.name_lineedit.text()

--- a/src/napari_timestamper/_timestamp_overlay.py
+++ b/src/napari_timestamper/_timestamp_overlay.py
@@ -257,9 +257,9 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
                 self.anchor_correction = 0
                 y_max, x_max = self.viewer.window._qt_viewer.canvas.size
 
-                self.node.parent = (
+                target_parent = (
                     self.viewer.window._qt_viewer.canvas.view
-                )  # this is a bit ugly and circumvents the overlay system which is not ideal but it works
+                )
             else:
                 self.anchor_correction = 0.5
                 x_max, y_max = (
@@ -279,9 +279,12 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
                     x_max += x_max_offset
                     y_max += y_max_offset
 
-                self.node.parent = (
+                target_parent = (
                     self.viewer.window._qt_viewer.canvas.view.scene
-                )  # this is a bit ugly and circumvents the overlay system which is not ideal but it works
+                )
+
+            if self.node.parent is not target_parent:
+                self.node.parent = target_parent
 
         if position == CanvasPosition.TOP_LEFT:
             anchors = ("left", "bottom")

--- a/src/napari_timestamper/_timestamp_overlay.py
+++ b/src/napari_timestamper/_timestamp_overlay.py
@@ -23,6 +23,7 @@ from napari.components._viewer_constants import CanvasPosition
 from napari.components.overlays import SceneOverlay
 from napari.utils.color import ColorValue
 from napari.utils.events import disconnect_events
+from pydantic import ConfigDict
 from vispy.color import ColorArray
 from vispy.visuals.transforms import STTransform
 
@@ -34,6 +35,8 @@ class TimestampOverlay(SceneOverlay):
     """
     Timestamp Overlay.
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     color: ColorValue = (0, 1, 0, 1)
     size: int = 10
@@ -141,7 +144,7 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
     Vispy Timestamp Overlay.
     """
 
-    def __init__(self, *, viewer, overlay, parent=None):
+    def __init__(self, *, viewer, overlay, parent=None, **kwargs):
         super().__init__(
             node=TextWithBoxVisual(
                 text=overlay.text,
@@ -152,6 +155,7 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
             viewer=viewer,
             overlay=overlay,
             parent=parent,
+            **kwargs,
         )
         self.anchor_correction = 0.5
         self.y_spacer = self.overlay.y_spacer
@@ -177,7 +181,6 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.overlay.events.outline_color.connect(self._on_text_change)
         self.overlay.events.outline_thickness.connect(self._on_text_change)
 
-        self.overlay.events.text.connect(self._on_text_change)
         self.overlay.events.y_spacer.connect(self._update_offsets)
         self.overlay.events.x_spacer.connect(self._update_offsets)
         self.overlay.events.time_format.connect(self._on_text_change)

--- a/src/napari_timestamper/_timestamp_overlay.py
+++ b/src/napari_timestamper/_timestamp_overlay.py
@@ -1,14 +1,22 @@
 """
 This module contains the TimestampOverlay class and the VispyTimestampOverlay class.
 
-The TimestampOverlay class is a canvas overlay that displays a timestamp on a napari viewer.
-It has several customizable properties such as color, size, prefix, suffix, time, start_time, step_size,
-time_format, y_position_offset, x_position_offset, and time_axis.
+GRID MODE FIX
+-------------
+In napari >= 0.6.2, grid mode uses per-layer ViewBoxes.  Layers no longer
+have world-space translations for their grid positions, so _find_grid_offsets()
+returns zeros, making x_max/y_max cover only one layer's extent instead of the
+full grid.
 
-The VispyTimestampOverlay class is a vispy canvas overlay that displays the TimestampOverlay on a napari viewer.
-It inherits from the ViewerOverlayMixin and VispyCanvasOverlay classes.
+Fix: when grid mode is active and display_on_scene=True, treat positioning
+exactly like display_on_scene=False (canvas-space, parent = canvas.view,
+bounds = canvas pixel size).  The timestamp appears once, correctly sized and
+placed across the full canvas.
 
-This structure is adapted from the napari dev example.
+In non-grid mode the existing scene-space behaviour is unchanged.
+
+Also added connections to viewer.grid.events.enabled/shape/stride/spacing so
+the overlay repositions correctly whenever the grid configuration changes.
 """
 
 import contextlib
@@ -28,7 +36,6 @@ from vispy.color import ColorArray
 from vispy.visuals.transforms import STTransform
 
 from napari_timestamper.text_visual import TextWithBoxVisual
-from napari_timestamper.utils import _find_grid_offsets
 
 
 class TimestampOverlay(SceneOverlay):
@@ -102,14 +109,6 @@ class TimestampOverlay(SceneOverlay):
             raise ValueError(f"Unknown format specifier: {format_specifier}")
 
     def _get_allowed_format_specifiers():
-        """
-        Returns a list of allowed format specifiers.
-
-        Returns
-        -------
-        list of str
-            A list of allowed format specifiers.
-        """
         return [
             "HH:MM:SS",
             "HH:MM:SS.ss",
@@ -128,14 +127,6 @@ class TimestampOverlay(SceneOverlay):
 
     @property
     def text(self):
-        """
-        Returns the formatted timestamp string.
-
-        Returns
-        -------
-        str
-            The formatted timestamp string.
-        """
         return self._timestamp_string()
 
 
@@ -160,17 +151,13 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.anchor_correction = 0.5
         self.y_spacer = self.overlay.y_spacer
         self.x_spacer = self.overlay.x_spacer
-        self.x_size = (
-            0  # this is not changed anywhere but for consistency is set to 0
-        )
-        self.y_size = (
-            0  # this is not changed anywhere but for consistency is set to 0
-        )
+        self.x_size = 0
+        self.y_size = 0
         self.camera_scaling_factor = 1
         self.node.transform = STTransform()
         self.overlay.events.position.connect(self._on_position_change)
 
-        # setup callbacks
+        # overlay property callbacks
         self.overlay.events.color.connect(self._on_color_change)
         self.overlay.events.size.connect(self._on_size_change)
         self.overlay.events.bold.connect(self._on_text_change)
@@ -180,7 +167,6 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.overlay.events.show_outline.connect(self._on_text_change)
         self.overlay.events.outline_color.connect(self._on_text_change)
         self.overlay.events.outline_thickness.connect(self._on_text_change)
-
         self.overlay.events.y_spacer.connect(self._update_offsets)
         self.overlay.events.x_spacer.connect(self._update_offsets)
         self.overlay.events.time_format.connect(self._on_text_change)
@@ -191,16 +177,55 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.overlay.events.time_axis.connect(self._on_text_change)
         self.overlay.events.scale_with_zoom.connect(self._on_size_change)
         self.overlay.events.display_on_scene.connect(self._on_position_change)
+
+        # viewer callbacks
         self.viewer.dims.events.current_step.connect(self._on_time_change)
         self.viewer.camera.events.zoom.connect(self._on_viewer_zoom_change)
         self.viewer.dims.events.ndisplay.connect(self._on_text_change)
+
+        # Grid events: _on_position_change handles the canvas/scene switch
+        self.viewer.grid.events.enabled.connect(self._on_position_change)
+        self.viewer.grid.events.shape.connect(self._on_position_change)
+        self.viewer.grid.events.stride.connect(self._on_position_change)
+        self.viewer.grid.events.spacing.connect(self._on_position_change)
+
         self.node.events.parent_change.connect(self._on_parent_change)
         self.reset()
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _in_grid_scene_mode(self) -> bool:
+        """
+        True when grid mode is active AND display_on_scene is True.
+
+        In this state we fall back to canvas-space positioning because
+        layer world-space translations are no longer meaningful in the
+        ViewBox-based grid (each layer is at origin inside its own ViewBox).
+        """
+        return self.viewer.grid.enabled and self.overlay.display_on_scene
+
+    def _canvas_bounds(self):
+        """Return (x_max, y_max) in canvas pixels."""
+        try:
+            h, w = self.viewer.window._qt_viewer.canvas.size
+            return w, h
+        except (AttributeError, TypeError):
+            return 1, 1
+
+    def _scene_bounds(self):
+        """Return (x_max, y_max) in scene/world units for non-grid mode."""
+        return (
+            self.viewer.dims.range[-1][-2],
+            self.viewer.dims.range[-2][-2],
+        )
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
+
     def _update_offsets(self, event=None):
-        """
-        Callback function for when the offsets of the overlay are changed.
-        """
         self.x_spacer = self.overlay.x_spacer
         self.y_spacer = self.overlay.y_spacer
         self._on_position_change()
@@ -211,23 +236,16 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
                 disconnect_events(self, event.old.canvas)
 
         if event.new is not None and self.node.canvas is not None:
-            # connect the canvas resize to recalculating the position
             event.new.canvas.events.resize.connect(self._on_position_change)
 
         self._on_viewer_zoom_change()
         self._on_text_change()
 
     def _on_viewer_zoom_change(self, event=None):
-        """
-        Callback function for when the viewer is zoomed.
-        """
         self.camera_scaling_factor = self.viewer.camera.zoom
         self._on_size_change()
 
     def _on_color_change(self, event=None):
-        """
-        Callback function for when the color of the overlay is changed.
-        """
         self.node.color = self.overlay.color
 
     def get_max_layer_scale(self):
@@ -242,112 +260,91 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         )
 
     def _on_position_change(self, event=None):
-        """
-        Callback function for when the position of the overlay is changed.
-        """
-        max_layer_scale = self.get_max_layer_scale()
-        # filter FutureWarnings from napari
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             position = self.overlay.position
             if self.node.canvas is None:
                 return
 
-            if not self.overlay.display_on_scene:
+            canvas = self.viewer.window._qt_viewer.canvas
+            in_grid_scene = self._in_grid_scene_mode()
+
+            # ----------------------------------------------------------
+            # Choose coordinate space and parent
+            # ----------------------------------------------------------
+            if not self.overlay.display_on_scene or in_grid_scene:
+                # Canvas-space: display_on_scene=False  OR  grid mode.
+                # In grid mode, world-space translations between layers are
+                # gone (each ViewBox has its own origin), so we use the full
+                # canvas size to position correctly across the entire grid.
                 self.anchor_correction = 0
-                y_max, x_max = self.viewer.window._qt_viewer.canvas.size
-
-                target_parent = (
-                    self.viewer.window._qt_viewer.canvas.view
-                )
+                x_max, y_max = self._canvas_bounds()
+                target_parent = canvas.view
             else:
+                # Scene-space (non-grid, display_on_scene=True)
                 self.anchor_correction = 0.5
-                x_max, y_max = (
-                    self.viewer.dims.range[-1][-2],  # max y + step size
-                    self.viewer.dims.range[-2][-2],  # max x + step size
-                )
-
-                if self.viewer.grid.enabled:
-                    layer_translations = _find_grid_offsets(self.viewer)
-                    # find maximum x and y translation
-                    x_max_offset = max(
-                        [translation[-1] for translation in layer_translations]
-                    )
-                    y_max_offset = max(
-                        [translation[-2] for translation in layer_translations]
-                    )
-                    x_max += x_max_offset
-                    y_max += y_max_offset
-
-                target_parent = (
-                    self.viewer.window._qt_viewer.canvas.view.scene
-                )
+                x_max, y_max = self._scene_bounds()
+                target_parent = canvas.view.scene
 
             if self.node.parent is not target_parent:
                 self.node.parent = target_parent
 
+        max_layer_scale = self.get_max_layer_scale()
+        ac = self.anchor_correction * max_layer_scale
+
+        # Label height in current coordinate units (world units in scene mode,
+        # pixels in canvas mode). anchor_y="bottom" (dy=0) means rect extends
+        # DOWNWARD from pos_y; placing pos_y = y_max - label_h puts the rect
+        # flush with the bottom edge, same as the layer annotator overlay.
+        label_h = self.overlay.size * TextWithBoxVisual.RECTANGLE_SCALER
+
         if position == CanvasPosition.TOP_LEFT:
             anchors = ("left", "bottom")
-            transform = [
-                self.x_spacer - self.anchor_correction * max_layer_scale,
-                self.y_spacer - self.anchor_correction * max_layer_scale,
-                0,
-                0,
-            ]
+            transform = [self.x_spacer - ac, self.y_spacer - ac, 0, 0]
 
         elif position == CanvasPosition.TOP_RIGHT:
             anchors = ("right", "bottom")
             transform = [
-                x_max
-                - self.x_size
-                - self.x_spacer
-                + self.anchor_correction * max_layer_scale,
-                self.y_spacer - self.anchor_correction * max_layer_scale,
+                x_max - self.x_size - self.x_spacer + ac,
+                self.y_spacer - ac,
                 0,
                 0,
             ]
+
         elif position == CanvasPosition.TOP_CENTER:
+            anchors = ("center", "bottom")
             transform = [
                 x_max / 2 - self.x_size / 2 + self.x_spacer,
-                self.y_spacer - self.anchor_correction * max_layer_scale,
+                self.y_spacer - ac,
                 0,
                 0,
             ]
-            anchors = ("center", "bottom")
 
         elif position == CanvasPosition.BOTTOM_RIGHT:
-            anchors = ("right", "top")
+            # anchor_y="bottom" (dy=0): rect extends DOWNWARD from pos_y.
+            # pos_y = y_max - label_h places rect flush with the bottom edge.
+            anchors = ("right", "bottom")
             transform = [
-                x_max
-                - self.x_size
-                - self.x_spacer
-                + self.anchor_correction * max_layer_scale,
-                y_max
-                - self.y_size
-                - self.y_spacer
-                + self.anchor_correction * max_layer_scale,
+                x_max - self.x_size - self.x_spacer + ac,
+                y_max - label_h - self.y_spacer,
                 0,
                 0,
             ]
+
         elif position == CanvasPosition.BOTTOM_LEFT:
-            anchors = ("left", "top")
+            anchors = ("left", "bottom")
             transform = [
-                self.x_spacer - self.anchor_correction * max_layer_scale,
-                y_max
-                - self.y_size
-                - self.y_spacer
-                + self.anchor_correction * max_layer_scale,
+                self.x_spacer - ac,
+                y_max - label_h - self.y_spacer,
                 0,
                 0,
             ]
+
         elif position == CanvasPosition.BOTTOM_CENTER:
-            anchors = ("center", "top")
+            anchors = ("center", "bottom")
             transform = [
                 x_max / 2 - self.x_size / 2 + self.x_spacer,
-                y_max
-                - self.y_size
-                - self.y_spacer
-                + self.anchor_correction * max_layer_scale,
+                y_max - label_h - self.y_spacer,
                 0,
                 0,
             ]
@@ -355,17 +352,24 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.node.transform.translate = transform
         self.node.anchors = anchors
         self.node._rectagles_visual.spacer = self.overlay.x_spacer
-        if self.viewer.dims.ndisplay == 3 and self.overlay.display_on_scene:
-            self.node.show_background = False
-            self.node.show_outline = False
-        else:
-            self.node.show_background = self.overlay.show_background
-            self.node.show_outline = self.overlay.show_outline
+
+        in_3d_scene = (
+            self.viewer.dims.ndisplay == 3 and self.overlay.display_on_scene
+        )
+        self.node.show_background = (
+            False if in_3d_scene else self.overlay.show_background
+        )
+        self.node.show_outline = (
+            False if in_3d_scene else self.overlay.show_outline
+        )
+
+        # box_width spans the full width of whatever space we're in
         box_width = (
-            x_max + 1 * max_layer_scale
-            if self.overlay.display_on_scene
+            x_max + max_layer_scale  # scene-space: add pixel-centre margin
+            if self.overlay.display_on_scene and not in_grid_scene
             else x_max
         )
+
         self.node.update_data(
             text=[self.overlay.text],
             color=[self.overlay.color],
@@ -376,12 +380,15 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         )
 
     def _on_size_change(self, event=None):
-        """
-        Callback function for when the size of the overlay is changed.
-        """
-        on_scene = self.overlay.display_on_scene
+        in_grid_scene = self._in_grid_scene_mode()
+        # Effective "on_scene": True only when in non-grid scene mode
+        on_scene = self.overlay.display_on_scene and not in_grid_scene
 
-        if self.overlay.scale_with_zoom and on_scene:
+        if in_grid_scene:
+            # Canvas-space in grid mode: no zoom scaling of size
+            self.node.scale_factor = 1
+            self.node.rectangles_scale_factor = 1
+        elif self.overlay.scale_with_zoom and on_scene:
             self.node.scale_factor = self.camera_scaling_factor
             self.node.rectangles_scale_factor = 1
         elif not self.overlay.scale_with_zoom and not on_scene:
@@ -400,20 +407,18 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
 
         self.node.font_size = self.overlay.size
         self.node.outline_thickness = self.overlay.outline_thickness
-
         self._on_position_change()
 
     def _on_text_change(self, event=None):
-        """
-        Callback function for when the text of the overlay is changed.
-        """
-        if self.viewer.dims.ndisplay == 3 and self.overlay.display_on_scene:
-            self.node.show_background = False
-            self.node.show_outline = False
-        else:
-            self.node.show_background = self.overlay.show_background
-            self.node.show_outline = self.overlay.show_outline
-
+        in_3d_scene = (
+            self.viewer.dims.ndisplay == 3 and self.overlay.display_on_scene
+        )
+        self.node.show_background = (
+            False if in_3d_scene else self.overlay.show_background
+        )
+        self.node.show_outline = (
+            False if in_3d_scene else self.overlay.show_outline
+        )
         self.node.text = self.overlay.text
         self.node.bold = self.overlay.bold
         self.node.italic = self.overlay.italic
@@ -422,18 +427,12 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.node.outline_thickness = self.overlay.outline_thickness
 
     def _on_time_change(self, event=None):
-        """
-        Callback function for when the time of the overlay is changed.
-        """
         self.overlay.time = self.viewer.dims.current_step[
             self.overlay.time_axis
         ]
         self.node.text = self.overlay.text
 
     def reset(self):
-        """
-        Resets the overlay to its initial state.
-        """
         super().reset()
         self._on_color_change()
         self._on_size_change()

--- a/src/napari_timestamper/_timestamp_overlay.py
+++ b/src/napari_timestamper/_timestamp_overlay.py
@@ -255,10 +255,10 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
 
             if not self.overlay.display_on_scene:
                 self.anchor_correction = 0
-                y_max, x_max = self.viewer.window.qt_viewer.canvas.size
+                y_max, x_max = self.viewer.window._qt_viewer.canvas.size
 
                 self.node.parent = (
-                    self.viewer.window.qt_viewer.canvas.view
+                    self.viewer.window._qt_viewer.canvas.view
                 )  # this is a bit ugly and circumvents the overlay system which is not ideal but it works
             else:
                 self.anchor_correction = 0.5
@@ -280,7 +280,7 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
                     y_max += y_max_offset
 
                 self.node.parent = (
-                    self.viewer.window.qt_viewer.canvas.view.scene
+                    self.viewer.window._qt_viewer.canvas.view.scene
                 )  # this is a bit ugly and circumvents the overlay system which is not ideal but it works
 
         if position == CanvasPosition.TOP_LEFT:
@@ -305,7 +305,7 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
             ]
         elif position == CanvasPosition.TOP_CENTER:
             transform = [
-                x_max / 2 - self.x_size / 2,
+                x_max / 2 - self.x_size / 2 + self.x_spacer,
                 self.y_spacer - self.anchor_correction * max_layer_scale,
                 0,
                 0,
@@ -340,7 +340,7 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         elif position == CanvasPosition.BOTTOM_CENTER:
             anchors = ("center", "top")
             transform = [
-                x_max / 2 - self.x_size / 2,
+                x_max / 2 - self.x_size / 2 + self.x_spacer,
                 y_max
                 - self.y_size
                 - self.y_spacer
@@ -352,6 +352,12 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         self.node.transform.translate = transform
         self.node.anchors = anchors
         self.node._rectagles_visual.spacer = self.overlay.x_spacer
+        if self.viewer.dims.ndisplay == 3 and self.overlay.display_on_scene:
+            self.node.show_background = False
+            self.node.show_outline = False
+        else:
+            self.node.show_background = self.overlay.show_background
+            self.node.show_outline = self.overlay.show_outline
         box_width = (
             x_max + 1 * max_layer_scale
             if self.overlay.display_on_scene
@@ -370,49 +376,27 @@ class VispyTimestampOverlay(ViewerOverlayMixin, VispySceneOverlay):
         """
         Callback function for when the size of the overlay is changed.
         """
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            if (
-                self.overlay.scale_with_zoom
-                and self.node.parent
-                is self.viewer.window.qt_viewer.canvas.view.scene
-            ):
-                self.node.scale_factor = self.camera_scaling_factor
-                self.node.font_size = self.overlay.size
-                self.node.outline_thickness = self.overlay.outline_thickness
-                self.node.rectangles_scale_factor = 1
+        on_scene = self.overlay.display_on_scene
 
-            elif (
-                not self.overlay.scale_with_zoom
-                and self.node.parent
-                is self.viewer.window.qt_viewer.canvas.view
-            ):
-                self.node.scale_factor = 1
-                self.node.font_size = self.overlay.size
-                self.node.outline_thickness = self.overlay.outline_thickness
-                self.node.rectangles_scale_factor = 1
+        if self.overlay.scale_with_zoom and on_scene:
+            self.node.scale_factor = self.camera_scaling_factor
+            self.node.rectangles_scale_factor = 1
+        elif not self.overlay.scale_with_zoom and not on_scene:
+            self.node.scale_factor = 1
+            self.node.rectangles_scale_factor = 1
+        elif not self.overlay.scale_with_zoom and on_scene:
+            self.node.scale_factor = 1
+            self.node.rectangles_scale_factor = (
+                1 / self.camera_scaling_factor
+                if self.camera_scaling_factor
+                else 1
+            )
+        elif self.overlay.scale_with_zoom and not on_scene:
+            self.node.scale_factor = self.camera_scaling_factor
+            self.node.rectangles_scale_factor = self.camera_scaling_factor
 
-            elif (
-                not self.overlay.scale_with_zoom
-                and self.node.parent
-                is self.viewer.window.qt_viewer.canvas.view.scene
-            ):
-                self.node.scale_factor = 1
-                self.node.rectangles_scale_factor = (
-                    1 / self.camera_scaling_factor
-                )
-                self.node.outline_thickness = self.overlay.outline_thickness
-                self.node.font_size = self.overlay.size
-
-            elif (
-                self.overlay.scale_with_zoom
-                and self.node.parent
-                is self.viewer.window.qt_viewer.canvas.view
-            ):
-                self.node.scale_factor = self.camera_scaling_factor
-                self.node.rectangles_scale_factor = self.camera_scaling_factor
-                self.node.outline_thickness = self.overlay.outline_thickness
-                self.node.font_size = self.overlay.size
+        self.node.font_size = self.overlay.size
+        self.node.outline_thickness = self.overlay.outline_thickness
 
         self._on_position_change()
 

--- a/src/napari_timestamper/_widget.py
+++ b/src/napari_timestamper/_widget.py
@@ -492,24 +492,32 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.toggle_visibility_button.setCheckable(True)
         self.toggle_visibility_button.setChecked(True)
 
+        # Layer selector
+        self.layer_selector_label = QtWidgets.QLabel("Annotate Layers")
+        self.layer_selector = QListWidget()
+        self._update_layer_selector()
+
         # Adding Widgets to Layout
-        self.gridLayout.addWidget(self.size_label, 0, 0)
-        self.gridLayout.addWidget(self.size_slider, 0, 1)
+        self.gridLayout.addWidget(self.layer_selector_label, 0, 0)
+        self.gridLayout.addWidget(self.layer_selector, 0, 1)
 
-        self.gridLayout.addWidget(self.position_label, 1, 0)
-        self.gridLayout.addWidget(self.position_combobox, 1, 1)
+        self.gridLayout.addWidget(self.size_label, 1, 0)
+        self.gridLayout.addWidget(self.size_slider, 1, 1)
 
-        self.gridLayout.addWidget(self.xy_offset_label, 2, 0)
-        self.gridLayout.addLayout(self.offset_layout, 2, 1)
+        self.gridLayout.addWidget(self.position_label, 2, 0)
+        self.gridLayout.addWidget(self.position_combobox, 2, 1)
 
-        self.gridLayout.addWidget(self.toggle_visibility_button, 10, 0, 1, 2)
+        self.gridLayout.addWidget(self.xy_offset_label, 3, 0)
+        self.gridLayout.addLayout(self.offset_layout, 3, 1)
+
+        self.gridLayout.addWidget(self.toggle_visibility_button, 11, 0, 1, 2)
 
         # Choose wether to use layer color or custom color by ticking the checkbox
         self.color_checkbox = QtWidgets.QCheckBox(
             "Use Colormap for Image Layers"
         )
         self.color_checkbox.setChecked(True)
-        self.gridLayout.addWidget(self.color_checkbox, 4, 0)
+        self.gridLayout.addWidget(self.color_checkbox, 5, 0)
 
         # Color Picker
         self.color = QtWidgets.QPushButton("Choose Color")
@@ -518,21 +526,21 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         )  # Update button icon
 
         # Adding Color Picker to Layout
-        self.gridLayout.addWidget(self.color, 4, 1)
+        self.gridLayout.addWidget(self.color, 5, 1)
 
         # Add Checkbox for bold and italic
         self.bold_checkbox = QtWidgets.QCheckBox("Bold")
         self.bold_checkbox.setChecked(False)
-        self.gridLayout.addWidget(self.bold_checkbox, 5, 0)
+        self.gridLayout.addWidget(self.bold_checkbox, 6, 0)
 
         self.italic_checkbox = QtWidgets.QCheckBox("Italic")
         self.italic_checkbox.setChecked(False)
-        self.gridLayout.addWidget(self.italic_checkbox, 5, 1)
+        self.gridLayout.addWidget(self.italic_checkbox, 6, 1)
 
         # Choose wether to use layer color or custom color by ticking the checkbox
         self.bgcolor_checkbox = QtWidgets.QCheckBox("Show Background Color")
         self.bgcolor_checkbox.setChecked(False)
-        self.gridLayout.addWidget(self.bgcolor_checkbox, 6, 0)
+        self.gridLayout.addWidget(self.bgcolor_checkbox, 7, 0)
 
         # Color Picker
         self.bgcolor = QtWidgets.QPushButton("Choose Color")
@@ -541,7 +549,7 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         )  # Update button icon
 
         # Adding Color Picker to Layout
-        self.gridLayout.addWidget(self.bgcolor, 6, 1)
+        self.gridLayout.addWidget(self.bgcolor, 7, 1)
 
         # opacity Slider
         self.opacity_label = QtWidgets.QLabel("Background Opacity")
@@ -551,8 +559,8 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.opacity_slider.setValue(100)
 
         # Adding Widgets to Layout
-        self.gridLayout.addWidget(self.opacity_label, 7, 0)
-        self.gridLayout.addWidget(self.opacity_slider, 7, 1)
+        self.gridLayout.addWidget(self.opacity_label, 8, 0)
+        self.gridLayout.addWidget(self.opacity_slider, 8, 1)
 
         # Choose wether to show outline or not
         self.outline_checkbox = QtWidgets.QCheckBox("Show Outline")
@@ -566,8 +574,8 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         )  # Update button icon
 
         # Adding Widgets to Layout
-        self.gridLayout.addWidget(self.outline_checkbox, 8, 0)
-        self.gridLayout.addWidget(self.outline_color, 8, 1)
+        self.gridLayout.addWidget(self.outline_checkbox, 9, 0)
+        self.gridLayout.addWidget(self.outline_color, 9, 1)
 
         # set outline size
         self.outline_size_label = QtWidgets.QLabel("Outline Size")
@@ -576,8 +584,8 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.outline_size.setValue(0.2)
 
         # Adding Widgets to Layout
-        self.gridLayout.addWidget(self.outline_size_label, 9, 0)
-        self.gridLayout.addWidget(self.outline_size, 9, 1)
+        self.gridLayout.addWidget(self.outline_size_label, 10, 0)
+        self.gridLayout.addWidget(self.outline_size, 10, 1)
 
         self.spacer = QtWidgets.QSpacerItem(
             20,
@@ -585,7 +593,7 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
             QtWidgets.QSizePolicy.Minimum,
             QtWidgets.QSizePolicy.Expanding,
         )
-        self.gridLayout.addItem(self.spacer, 11, 0, 1, 2)
+        self.gridLayout.addItem(self.spacer, 12, 0, 1, 2)
 
         # Set the layout to the widget
         self.setLayout(self.gridLayout)
@@ -599,6 +607,49 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.bgcolor_checkbox.stateChanged.connect(
             self._on_background_color_combobox_change
         )
+        self.viewer.layers.events.inserted.connect(
+            self._update_layer_selector
+        )
+        self.viewer.layers.events.removed.connect(
+            self._update_layer_selector
+        )
+        self.layer_selector.itemChanged.connect(
+            self._on_layer_selection_changed
+        )
+
+    def _update_layer_selector(self, event=None):
+        self.layer_selector.blockSignals(True)
+        selected = self._get_selected_layer_names()
+        self.layer_selector.clear()
+        for layer in self.viewer.layers:
+            item = QListWidgetItem(layer.name)
+            if layer.name in selected or not selected:
+                item.setCheckState(QtCore.Qt.Checked)
+            else:
+                item.setCheckState(QtCore.Qt.Unchecked)
+            self.layer_selector.addItem(item)
+        self.layer_selector.blockSignals(False)
+        self._on_layer_selection_changed()
+
+    def _get_selected_layer_names(self):
+        return {
+            self.layer_selector.item(i).text()
+            for i in range(self.layer_selector.count())
+            if self.layer_selector.item(i).checkState() == QtCore.Qt.Checked
+        }
+
+    def _on_layer_selection_changed(self, item=None):
+        if not self.overlay_set:
+            return
+        canvas = self.viewer.window._qt_viewer.canvas
+        vispy_overlays = canvas._overlay_to_visual.get(
+            self.layer_annotator_overlay, []
+        )
+        if vispy_overlays:
+            vispy_overlays[0].selected_layer_names = (
+                self._get_selected_layer_names()
+            )
+            vispy_overlays[0]._update_annotations()
 
     def _update_color_button_icon(self, color_button, color_str):
         pixmap = QtGui.QPixmap(20, 20)  # Create a QPixmap of size 20x20

--- a/src/napari_timestamper/_widget.py
+++ b/src/napari_timestamper/_widget.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import napari
 from napari._vispy.utils.visual import overlay_to_visual
 from napari.components._viewer_constants import CanvasPosition
+from napari.layers import labels
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Slot
 from qtpy.QtWidgets import (
@@ -105,8 +106,8 @@ class TimestampWidget(QtWidgets.QWidget):
         self.gridLayout = QtWidgets.QGridLayout()
 
         self.time_axis_label = QtWidgets.QLabel("Time Axis")
-        self.time_axis = QtWidgets.QSpinBox()
-        self.time_axis.setRange(-10, 10)
+        self.time_axis = QtWidgets.QComboBox()
+        self._update_time_axis_combobox()
 
         self.start_time_label = QtWidgets.QLabel("Start Time")
         self.start_time = QtWidgets.QSpinBox()
@@ -342,7 +343,9 @@ class TimestampWidget(QtWidgets.QWidget):
         timestamp_overlay.time_format = self.time_format.currentText()
         timestamp_overlay.x_spacer = self.x_shift.value()
         timestamp_overlay.y_spacer = self.y_shift.value()
-        timestamp_overlay.time_axis = self.time_axis.value()
+        time_axis = self.time_axis.currentData()
+        if time_axis is not None:
+            timestamp_overlay.time_axis = time_axis
         timestamp_overlay.display_on_scene = self.display_on_scene.isChecked()
         timestamp_overlay.scale_with_zoom = self.scale_with_zoom.isChecked()
         timestamp_overlay.bg_color = ColorArray(
@@ -353,9 +356,16 @@ class TimestampWidget(QtWidgets.QWidget):
         timestamp_overlay.outline_color = ColorArray(self.chosen_outline_color)
         timestamp_overlay.outline_thickness = self.outline_size.value()
 
+    def _update_time_axis_combobox(self, event=None):
+        self.time_axis.clear()
+        for i, axis in enumerate(self.viewer.dims.axis_labels[:-2]):
+            if axis is not None:
+                self.time_axis.addItem(axis, i)
+        if self.time_axis.count() > 0:
+            self.time_axis.setCurrentIndex(0)
+
     def _connect_all_changes(self):
         for i in [
-            self.time_axis,
             self.start_time,
             self.step_time,
             self.ts_size,
@@ -365,8 +375,14 @@ class TimestampWidget(QtWidgets.QWidget):
             i.valueChanged.connect(self._set_timestamp_overlay_options)
         for i in [self.prefix, self.suffix]:
             i.textChanged.connect(self._set_timestamp_overlay_options)
-        for i in [self.position, self.time_format]:
+        for i in [self.position, self.time_format, self.time_axis]:
             i.currentTextChanged.connect(self._set_timestamp_overlay_options)
+        self.viewer.layers.events.inserted.connect(
+            self._update_time_axis_combobox
+        )
+        self.viewer.layers.events.removed.connect(
+            self._update_time_axis_combobox
+        )
         self.toggle_timestamp.clicked.connect(self._toggle_overlay)
 
         self.color.clicked.connect(self._open_color_dialog)
@@ -970,6 +986,100 @@ class LayertoRGBWidget(QWidget):
             for layer_idx, layer in temporary_removed_layers.items():
                 self.viewer.layers.insert(layer_idx, layer)
         return rendered_image
+
+
+class SplitStackWidget(QWidget):
+    def __init__(self, viewer: napari.viewer.Viewer, parent=None):
+        super().__init__(parent)
+        self.viewer = viewer
+
+        self.layout = QVBoxLayout(self)
+
+        self.layer_label = QLabel("Layer:", self)
+        self.layout.addWidget(self.layer_label)
+
+        self.layer_combobox = QComboBox(self)
+        self.layout.addWidget(self.layer_combobox)
+
+        self.axis_label = QLabel("Split Axis:", self)
+        self.layout.addWidget(self.axis_label)
+
+        self.axis_combobox = QComboBox(self)
+        self.layout.addWidget(self.axis_combobox)
+
+        self.split_button = QPushButton("Split", self)
+        self.layout.addWidget(self.split_button)
+
+        self.spacer = QtWidgets.QSpacerItem(
+            20,
+            40,
+            QtWidgets.QSizePolicy.Minimum,
+            QtWidgets.QSizePolicy.Expanding,
+        )
+        self.layout.addItem(self.spacer)
+
+        self._update_layer_combobox()
+        self._connect_slots()
+
+    def _connect_slots(self):
+        self.viewer.layers.events.inserted.connect(
+            self._update_layer_combobox
+        )
+        self.viewer.layers.events.removed.connect(
+            self._update_layer_combobox
+        )
+        self.layer_combobox.currentIndexChanged.connect(
+            self._update_axis_combobox
+        )
+        self.split_button.clicked.connect(self._on_split)
+
+    def _update_layer_combobox(self, event=None):
+        self.layer_combobox.clear()
+        for layer in self.viewer.layers:
+            self.layer_combobox.addItem(layer.name)
+        self._update_axis_combobox()
+
+    def _update_axis_combobox(self, event=None):
+        self.axis_combobox.clear()
+        idx = self.layer_combobox.currentIndex()
+        if idx < 0 or idx >= len(self.viewer.layers):
+            return
+        layer = self.viewer.layers[idx]
+        ndim = layer.data.ndim
+        axis_labels = self.viewer.dims.axis_labels
+        for i in range(ndim):
+            axis_name = axis_labels[i] if i < len(axis_labels) else str(i)
+            label = f"{axis_name} (size {layer.data.shape[i]})"
+            self.axis_combobox.addItem(label, i)
+
+    def _on_split(self):
+        idx = self.layer_combobox.currentIndex()
+        if idx < 0 or idx >= len(self.viewer.layers):
+            return
+        layer = self.viewer.layers[idx]
+        axis = self.axis_combobox.currentData()
+        if axis is None:
+            return
+        data = layer.data
+        base_name = layer.name
+        is_labels = isinstance(layer, labels.Labels)
+
+        # collect properties that survive the dimension drop
+        scale = [s for i, s in enumerate(layer.scale) if i != axis]
+        translate = [t for i, t in enumerate(layer.translate) if i != axis]
+
+        kwargs = {"scale": scale, "translate": translate}
+        if not is_labels:
+            kwargs["contrast_limits"] = layer.contrast_limits
+            kwargs["colormap"] = layer.colormap.name
+            kwargs["blending"] = layer.blending
+
+        add_fn = self.viewer.add_labels if is_labels else self.viewer.add_image
+        for i in range(data.shape[axis]):
+            slicing = tuple(
+                slice(None) if a != axis else i for a in range(data.ndim)
+            )
+            add_fn(data[slicing], name=f"{base_name}_{i}", **kwargs)
 
 
 if __name__ == "__main__":

--- a/src/napari_timestamper/_widget.py
+++ b/src/napari_timestamper/_widget.py
@@ -1,6 +1,7 @@
 """
 Dock widget for napari-timestamper
 """
+
 from __future__ import annotations
 
 import warnings
@@ -29,9 +30,7 @@ from superqt import QLabeledSlider
 from vispy.color import ColorArray
 
 from napari_timestamper._layer_annotator_overlay import (
-    LayerAnnotatorOverlay,
-    ScenePosition,
-    VispyLayerAnnotatorOverlay,
+    LayerAnnotatorManager,
 )
 from napari_timestamper._timestamp_overlay import (
     TimestampOverlay,
@@ -43,28 +42,11 @@ from napari_timestamper.render_as_rgb import render_as_rgb, save_image_stack
 class TimestampWidget(QtWidgets.QWidget):
     """
     A widget that provides options for the timestamp overlay in napari viewer.
-
-    Parameters
-    ----------
-    viewer : napari.Viewer
-        The napari viewer instance.
-    parent : QWidget, optional
-        The parent widget, by default None.
     """
 
     overlay_set: bool = False
 
     def __init__(self, viewer: napari.viewer.Viewer, parent=None):
-        """
-        Initialize the timestamp_options widget.
-
-        Parameters
-        ----------
-        viewer : napari.Viewer
-            The napari viewer instance.
-        parent : QWidget, optional
-            The parent widget, by default None.
-        """
         super().__init__(parent)
         self.chosen_color = "white"
         self.chosen_bgcolor = "black"
@@ -73,6 +55,8 @@ class TimestampWidget(QtWidgets.QWidget):
         self._setupUi()
         self._connect_all_changes()
         self._setup_overlay()
+        # Reflect current grid state immediately on open
+        self._on_grid_mode_change()
 
     def _setup_overlay(self):
         with warnings.catch_warnings():
@@ -100,6 +84,26 @@ class TimestampWidget(QtWidgets.QWidget):
         else:
             self.timestamp_overlay.visible = True
             self.toggle_timestamp.setText("Remove Timestamp")
+
+    def _on_grid_mode_change(self, event=None):
+        """
+        Enable / disable scene-specific controls based on grid mode.
+
+        In grid mode the overlay ignores display_on_scene and scale_with_zoom
+        (it always uses canvas-space positioning with a fixed scale).
+        We grey those controls out so the user can see they're inactive,
+        but their Qt values are preserved — re-enabling them when grid mode
+        turns off automatically "recalls" the previous settings.
+        """
+        grid_on = self.viewer.grid.enabled
+
+        for widget in (self.display_on_scene, self.scale_with_zoom):
+            widget.setEnabled(not grid_on)
+
+        self.grid_mode_label.setVisible(grid_on)
+
+        if self.overlay_set:
+            self._set_timestamp_overlay_options()
 
     def _setupUi(self):
         self.setObjectName("Timestamp Options")
@@ -157,38 +161,30 @@ class TimestampWidget(QtWidgets.QWidget):
         self.color_label = QtWidgets.QLabel("Set Timestamp Color")
         self.color = QtWidgets.QPushButton("Choose Color")
 
-        # add checkbox for background
         self.bgcolor_checkbox = QtWidgets.QCheckBox("Background Color")
         self.bgcolor_checkbox.setChecked(False)
-
         self.bgcolor = QtWidgets.QPushButton("Choose Color")
         self.bgcolor.setEnabled(False)
 
-        # opacity Slider
         self.opacity_label = QtWidgets.QLabel("Background Opacity")
         self.opacity_slider = QLabeledSlider(QtCore.Qt.Horizontal)
         self.opacity_slider.setRange(0, 100)
         self.opacity_slider.setValue(100)
         self.opacity_label.setEnabled(False)
 
-        # outline checkbox
         self.outline_checkbox = QtWidgets.QCheckBox("Outline")
         self.outline_checkbox.setChecked(False)
 
-        # outline color
         self.outline_color = QtWidgets.QPushButton("Choose Outline Color")
         self.outline_color.setEnabled(False)
 
-        # outline_size
         self.outline_size_label = QtWidgets.QLabel("Outline Size")
         self.outline_size = QtWidgets.QDoubleSpinBox()
         self.outline_size.setRange(0, 100)
         self.outline_size.setValue(0.2)
 
-        # add checkbox for bold and italic
         self.bold_checkbox = QtWidgets.QCheckBox("Bold")
         self.bold_checkbox.setChecked(False)
-
         self.italic_checkbox = QtWidgets.QCheckBox("Italic")
         self.italic_checkbox.setChecked(False)
 
@@ -198,8 +194,20 @@ class TimestampWidget(QtWidgets.QWidget):
         self.scale_with_zoom = QtWidgets.QCheckBox("Scale with Zoom")
         self.scale_with_zoom.setChecked(True)
 
+        # Grid mode info label — hidden when grid is off
+        self.grid_mode_label = QtWidgets.QLabel(
+            "Grid mode active: 'Display on Scene' and\n"
+            "'Scale with Zoom' are ignored."
+        )
+        self.grid_mode_label.setStyleSheet(
+            "color: orange; font-style: italic;"
+        )
+        self.grid_mode_label.setVisible(False)
+        self.grid_mode_label.setWordWrap(True)
+
         self.toggle_timestamp = QtWidgets.QPushButton("Add Timestamp")
 
+        # Layout
         self.gridLayout.addWidget(self.time_axis_label, 0, 0)
         self.gridLayout.addWidget(self.time_axis, 0, 1)
         self.gridLayout.addWidget(self.start_time_label, 1, 0)
@@ -224,17 +232,17 @@ class TimestampWidget(QtWidgets.QWidget):
         self.gridLayout.addWidget(self.outline_color, 10, 1)
         self.gridLayout.addWidget(self.outline_size_label, 11, 0)
         self.gridLayout.addWidget(self.outline_size, 11, 1)
-
         self.gridLayout.addWidget(self.bgcolor_checkbox, 12, 0)
         self.gridLayout.addWidget(self.bgcolor, 12, 1)
         self.gridLayout.addWidget(self.opacity_label, 13, 0)
         self.gridLayout.addWidget(self.opacity_slider, 13, 1)
-
         self.gridLayout.addWidget(self.bold_checkbox, 14, 0)
         self.gridLayout.addWidget(self.italic_checkbox, 14, 1)
-        self.gridLayout.addWidget(self.display_on_scene, 15, 1)
         self.gridLayout.addWidget(self.scale_with_zoom, 15, 0)
-        self.gridLayout.addWidget(self.toggle_timestamp, 16, 0, 1, 2)
+        self.gridLayout.addWidget(self.display_on_scene, 15, 1)
+        # Grid mode info label spans both columns
+        self.gridLayout.addWidget(self.grid_mode_label, 16, 0, 1, 2)
+        self.gridLayout.addWidget(self.toggle_timestamp, 17, 0, 1, 2)
         self.setLayout(self.gridLayout)
 
         self.spacer = QtWidgets.QSpacerItem(
@@ -243,7 +251,7 @@ class TimestampWidget(QtWidgets.QWidget):
             QtWidgets.QSizePolicy.Minimum,
             QtWidgets.QSizePolicy.Expanding,
         )
-        self.gridLayout.addItem(self.spacer, 17, 0, 1, 2)
+        self.gridLayout.addItem(self.spacer, 18, 0, 1, 2)
 
         self._update_color_button_icon(self.color, self.chosen_color)
         self._update_color_button_icon(self.bgcolor, self.chosen_bgcolor)
@@ -252,12 +260,9 @@ class TimestampWidget(QtWidgets.QWidget):
         )
 
     def _update_color_button_icon(self, color_button, color_str):
-        pixmap = QtGui.QPixmap(20, 20)  # Create a QPixmap of size 20x20
-        pixmap.fill(
-            QtGui.QColor(color_str)
-        )  # Fill the pixmap with the chosen color
-        icon = QtGui.QIcon(pixmap)  # Convert pixmap to QIcon
-        color_button.setIcon(icon)  # Set the icon for the button
+        pixmap = QtGui.QPixmap(20, 20)
+        pixmap.fill(QtGui.QColor(color_str))
+        color_button.setIcon(QtGui.QIcon(pixmap))
 
     def _toggle_bgcolor(self):
         if self.bgcolor_checkbox.isChecked():
@@ -273,9 +278,6 @@ class TimestampWidget(QtWidgets.QWidget):
             self._set_timestamp_overlay_options()
 
     def _on_outline_color_combobox_change(self):
-        """
-        Slot function to handle changes in the outline color combobox.
-        """
         if not self.outline_checkbox.isChecked():
             self.outline_color.setEnabled(False)
             self._update_color_button_icon(self.outline_color, "grey")
@@ -365,18 +367,19 @@ class TimestampWidget(QtWidgets.QWidget):
             self.time_axis.setCurrentIndex(0)
 
     def _connect_all_changes(self):
-        for i in [
+        for w in (
             self.start_time,
             self.step_time,
             self.ts_size,
             self.x_shift,
             self.y_shift,
-        ]:
-            i.valueChanged.connect(self._set_timestamp_overlay_options)
-        for i in [self.prefix, self.suffix]:
-            i.textChanged.connect(self._set_timestamp_overlay_options)
-        for i in [self.position, self.time_format, self.time_axis]:
-            i.currentTextChanged.connect(self._set_timestamp_overlay_options)
+        ):
+            w.valueChanged.connect(self._set_timestamp_overlay_options)
+        for w in (self.prefix, self.suffix):
+            w.textChanged.connect(self._set_timestamp_overlay_options)
+        for w in (self.position, self.time_format, self.time_axis):
+            w.currentTextChanged.connect(self._set_timestamp_overlay_options)
+
         self.viewer.layers.events.inserted.connect(
             self._update_time_axis_combobox
         )
@@ -412,17 +415,15 @@ class TimestampWidget(QtWidgets.QWidget):
             self._set_timestamp_overlay_options
         )
 
+        # Grid mode: update widget state whenever grid changes
+        self.viewer.grid.events.enabled.connect(self._on_grid_mode_change)
+        self.viewer.grid.events.shape.connect(self._on_grid_mode_change)
+        self.viewer.grid.events.stride.connect(self._on_grid_mode_change)
+
 
 class LayerAnnotationsWidget(QtWidgets.QWidget):
     """
     A widget that provides options for the layer annotator overlay in napari viewer.
-
-    Parameters
-    ----------
-    viewer : napari.Viewer
-        The napari viewer instance.
-    parent : QWidget, optional
-        The parent widget, by default None.
     """
 
     overlay_set: bool = False
@@ -430,9 +431,10 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
     def __init__(self, viewer: napari.viewer.Viewer, parent=None):
         super().__init__(parent)
         self.viewer = viewer
-        self.chosen_color = "white"  # Default color
-        self.chosen_bgcolor = "black"  # Default color
-        self.chosen_outline_color = "white"  # Default color
+        self.chosen_color = "white"
+        self.chosen_bgcolor = "black"
+        self.chosen_outline_color = "white"
+        self._annotator_manager: LayerAnnotatorManager | None = None
         self._setupUi()
         self._connect_all_changes()
         self._setup_overlay()
@@ -440,95 +442,75 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self._on_color_combobox_change()
         self._on_background_color_combobox_change()
 
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
     def _setup_overlay(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            try:
-                self.viewer._overlays["LayerAnnotator"]
-            except KeyError:
-                overlay_to_visual[
-                    LayerAnnotatorOverlay
-                ] = VispyLayerAnnotatorOverlay
-                self.viewer._overlays[
-                    "LayerAnnotator"
-                ] = LayerAnnotatorOverlay(visible=True)
-            self.layer_annotator_overlay = self.viewer._overlays[
-                "LayerAnnotator"
-            ]
+            if self._annotator_manager is None:
+                self._annotator_manager = LayerAnnotatorManager(
+                    self.viewer, visible=True
+                )
             self._set_layer_annotator_overlay_options()
             self.overlay_set = True
+
+    @property
+    def layer_annotator_overlay(self):
+        """Return the first managed overlay for inspection / testing.
+
+        Returns None if no layers exist yet.
+        """
+        if self._annotator_manager is None:
+            return None
+        return self._annotator_manager.get_any_overlay()
+
+    # ------------------------------------------------------------------
+    # UI construction  (unchanged)
+    # ------------------------------------------------------------------
 
     def _setupUi(self):
         self.setObjectName("Layer Annotator Options")
         self.gridLayout = QtWidgets.QGridLayout(self)
 
-        # Size Slider
         self.size_label = QtWidgets.QLabel("Size")
         self.size_slider = QLabeledSlider(QtCore.Qt.Horizontal)
         self.size_slider.setRange(1, 100)
         self.size_slider.setValue(12)
 
-        # Position Selector
         self.position_label = QtWidgets.QLabel("Position")
         self.position_combobox = QtWidgets.QComboBox()
-        self.position_combobox.addItems(ScenePosition)
+        self.position_combobox.addItems(CanvasPosition)
 
-        # X and Y Position Offset
-        self.xy_offset_label = QtWidgets.QLabel("XY Position Offset")
-        self.x_offset_spinbox = QtWidgets.QSpinBox()
-        self.x_offset_spinbox.setRange(-1000, 1000)
-        self.x_offset_spinbox.setValue(0)
-        self.y_offset_spinbox = QtWidgets.QSpinBox()
-        self.y_offset_spinbox.setRange(-1000, 1000)
-        self.y_offset_spinbox.setValue(0)
-        self.offset_layout = QtWidgets.QHBoxLayout()
-        self.offset_layout.addWidget(self.x_offset_spinbox)
-        self.offset_layout.addWidget(self.y_offset_spinbox)
-
-        # Toggle Visibility Button
         self.toggle_visibility_button = QtWidgets.QPushButton(
             "Toggle Visibility"
         )
         self.toggle_visibility_button.setCheckable(True)
         self.toggle_visibility_button.setChecked(True)
 
-        # Layer selector
         self.layer_selector_label = QtWidgets.QLabel("Annotate Layers")
         self.layer_selector = QListWidget()
         self._update_layer_selector()
 
-        # Adding Widgets to Layout
         self.gridLayout.addWidget(self.layer_selector_label, 0, 0)
         self.gridLayout.addWidget(self.layer_selector, 0, 1)
-
         self.gridLayout.addWidget(self.size_label, 1, 0)
         self.gridLayout.addWidget(self.size_slider, 1, 1)
-
         self.gridLayout.addWidget(self.position_label, 2, 0)
         self.gridLayout.addWidget(self.position_combobox, 2, 1)
-
-        self.gridLayout.addWidget(self.xy_offset_label, 3, 0)
-        self.gridLayout.addLayout(self.offset_layout, 3, 1)
-
         self.gridLayout.addWidget(self.toggle_visibility_button, 11, 0, 1, 2)
 
-        # Choose wether to use layer color or custom color by ticking the checkbox
         self.color_checkbox = QtWidgets.QCheckBox(
             "Use Colormap for Image Layers"
         )
         self.color_checkbox.setChecked(True)
         self.gridLayout.addWidget(self.color_checkbox, 5, 0)
 
-        # Color Picker
         self.color = QtWidgets.QPushButton("Choose Color")
-        self._update_color_button_icon(
-            self.color, self.chosen_color
-        )  # Update button icon
-
-        # Adding Color Picker to Layout
+        self._update_color_button_icon(self.color, self.chosen_color)
         self.gridLayout.addWidget(self.color, 5, 1)
 
-        # Add Checkbox for bold and italic
         self.bold_checkbox = QtWidgets.QCheckBox("Bold")
         self.bold_checkbox.setChecked(False)
         self.gridLayout.addWidget(self.bold_checkbox, 6, 0)
@@ -537,53 +519,35 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.italic_checkbox.setChecked(False)
         self.gridLayout.addWidget(self.italic_checkbox, 6, 1)
 
-        # Choose wether to use layer color or custom color by ticking the checkbox
         self.bgcolor_checkbox = QtWidgets.QCheckBox("Show Background Color")
         self.bgcolor_checkbox.setChecked(False)
         self.gridLayout.addWidget(self.bgcolor_checkbox, 7, 0)
 
-        # Color Picker
         self.bgcolor = QtWidgets.QPushButton("Choose Color")
-        self._update_color_button_icon(
-            self.bgcolor, self.chosen_bgcolor
-        )  # Update button icon
-
-        # Adding Color Picker to Layout
+        self._update_color_button_icon(self.bgcolor, self.chosen_bgcolor)
         self.gridLayout.addWidget(self.bgcolor, 7, 1)
 
-        # opacity Slider
         self.opacity_label = QtWidgets.QLabel("Background Opacity")
-
         self.opacity_slider = QLabeledSlider(QtCore.Qt.Horizontal)
         self.opacity_slider.setRange(0, 100)
         self.opacity_slider.setValue(100)
-
-        # Adding Widgets to Layout
         self.gridLayout.addWidget(self.opacity_label, 8, 0)
         self.gridLayout.addWidget(self.opacity_slider, 8, 1)
 
-        # Choose wether to show outline or not
         self.outline_checkbox = QtWidgets.QCheckBox("Show Outline")
         self.outline_checkbox.setChecked(False)
-
-        # set outline color
         self.outline_color = QtWidgets.QPushButton("Choose Outline Color")
         self.outline_color.setEnabled(False)
         self._update_color_button_icon(
             self.outline_color, self.chosen_outline_color
-        )  # Update button icon
-
-        # Adding Widgets to Layout
+        )
         self.gridLayout.addWidget(self.outline_checkbox, 9, 0)
         self.gridLayout.addWidget(self.outline_color, 9, 1)
 
-        # set outline size
         self.outline_size_label = QtWidgets.QLabel("Outline Size")
         self.outline_size = QtWidgets.QDoubleSpinBox()
         self.outline_size.setRange(0, 100)
         self.outline_size.setValue(0.2)
-
-        # Adding Widgets to Layout
         self.gridLayout.addWidget(self.outline_size_label, 10, 0)
         self.gridLayout.addWidget(self.outline_size, 10, 1)
 
@@ -594,11 +558,8 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
             QtWidgets.QSizePolicy.Expanding,
         )
         self.gridLayout.addItem(self.spacer, 12, 0, 1, 2)
-
-        # Set the layout to the widget
         self.setLayout(self.gridLayout)
 
-        # Connect the toggle visibility button to its slot
         self.size_slider.valueChanged.connect(self._on_size_slider_change)
         self.toggle_visibility_button.clicked.connect(self._toggle_visibility)
         self.color_checkbox.stateChanged.connect(
@@ -607,15 +568,15 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.bgcolor_checkbox.stateChanged.connect(
             self._on_background_color_combobox_change
         )
-        self.viewer.layers.events.inserted.connect(
-            self._update_layer_selector
-        )
-        self.viewer.layers.events.removed.connect(
-            self._update_layer_selector
-        )
+        self.viewer.layers.events.inserted.connect(self._update_layer_selector)
+        self.viewer.layers.events.removed.connect(self._update_layer_selector)
         self.layer_selector.itemChanged.connect(
             self._on_layer_selection_changed
         )
+
+    # ------------------------------------------------------------------
+    # Layer selector
+    # ------------------------------------------------------------------
 
     def _update_layer_selector(self, event=None):
         self.layer_selector.blockSignals(True)
@@ -631,7 +592,7 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         self.layer_selector.blockSignals(False)
         self._on_layer_selection_changed()
 
-    def _get_selected_layer_names(self):
+    def _get_selected_layer_names(self) -> set[str]:
         return {
             self.layer_selector.item(i).text()
             for i in range(self.layer_selector.count())
@@ -639,78 +600,75 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         }
 
     def _on_layer_selection_changed(self, item=None):
-        if not self.overlay_set:
+        """Show the overlay only for checked layers."""
+        if not self.overlay_set or self._annotator_manager is None:
             return
-        canvas = self.viewer.window._qt_viewer.canvas
-        vispy_overlays = canvas._overlay_to_visual.get(
-            self.layer_annotator_overlay, []
-        )
-        if vispy_overlays:
-            vispy_overlays[0].selected_layer_names = (
-                self._get_selected_layer_names()
-            )
-            vispy_overlays[0]._update_annotations()
+        selected = self._get_selected_layer_names()
+        for layer in self.viewer.layers:
+            # visible = selected if anything is ticked, otherwise show all
+            should_show = (layer.name in selected) if selected else True
+            self._annotator_manager.set_layer_visible(layer.name, should_show)
+
+    # ------------------------------------------------------------------
+    # Color helpers
+    # ------------------------------------------------------------------
 
     def _update_color_button_icon(self, color_button, color_str):
-        pixmap = QtGui.QPixmap(20, 20)  # Create a QPixmap of size 20x20
-        pixmap.fill(
-            QtGui.QColor(color_str)
-        )  # Fill the pixmap with the chosen color
-        icon = QtGui.QIcon(pixmap)  # Convert pixmap to QIcon
-        color_button.setIcon(icon)  # Set the icon for the button
+        pixmap = QtGui.QPixmap(20, 20)
+        pixmap.fill(QtGui.QColor(color_str))
+        color_button.setIcon(QtGui.QIcon(pixmap))
 
     def _on_color_combobox_change(self):
-        """
-        Slot function to handle changes in the color combobox.
-        """
-        if self.color_checkbox.isChecked():
-            self._update_color_button_icon(self.color, self.chosen_color)
-            self.layer_annotator_overlay.use_layer_color = True
-
-        else:
-            self.color.setEnabled(True)
-            self._update_color_button_icon(self.color, self.chosen_color)
-            self.layer_annotator_overlay.use_layer_color = False
-
+        use_layer_color = self.color_checkbox.isChecked()
+        self._update_color_button_icon(self.color, self.chosen_color)
+        if self.overlay_set:
+            self._annotator_manager.update_settings(
+                use_layer_color=use_layer_color
+            )
         self._set_layer_annotator_overlay_options()
 
     def _on_background_color_combobox_change(self):
-        """
-        Slot function to handle changes in the background color combobox.
-        """
         if not self.bgcolor_checkbox.isChecked():
             self.bgcolor.setEnabled(False)
             self._update_color_button_icon(self.bgcolor, "grey")
-            self.layer_annotator_overlay.show_background = False
             self.opacity_label.setEnabled(False)
             self.opacity_slider.setEnabled(False)
+            if self.overlay_set:
+                self._annotator_manager.update_settings(show_background=False)
         else:
             self.bgcolor.setEnabled(True)
             self._update_color_button_icon(self.bgcolor, self.chosen_bgcolor)
-            self.layer_annotator_overlay.show_background = True
-            self.layer_annotator_overlay.bg_color = ColorArray(
-                self.chosen_bgcolor, alpha=self.opacity_slider.value() / 100
-            )
             self.opacity_label.setEnabled(True)
             self.opacity_slider.setEnabled(True)
+            if self.overlay_set:
+                self._annotator_manager.update_settings(
+                    show_background=True,
+                    bg_color=ColorArray(
+                        self.chosen_bgcolor,
+                        alpha=self.opacity_slider.value() / 100,
+                    ),
+                )
 
     def _on_outline_color_combobox_change(self):
-        """
-        Slot function to handle changes in the outline color combobox.
-        """
         if not self.outline_checkbox.isChecked():
             self.outline_color.setEnabled(False)
             self._update_color_button_icon(self.outline_color, "grey")
-            self.layer_annotator_overlay.show_outline = False
+            if self.overlay_set:
+                self._annotator_manager.update_settings(show_outline=False)
         else:
             self.outline_color.setEnabled(True)
             self._update_color_button_icon(
-                self.outline_color, self.chosen_color
+                self.outline_color, self.chosen_outline_color
             )
-            self.layer_annotator_overlay.show_outline = True
-            self.layer_annotator_overlay.outline_color = ColorArray(
-                self.chosen_outline_color
-            )
+            if self.overlay_set:
+                self._annotator_manager.update_settings(
+                    show_outline=True,
+                    outline_color=ColorArray(self.chosen_outline_color),
+                )
+
+    # ------------------------------------------------------------------
+    # Color dialogs
+    # ------------------------------------------------------------------
 
     def _open_color_dialog(self):
         self.color_dialog = QtWidgets.QColorDialog(parent=self)
@@ -735,7 +693,7 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         color = self.color_dialog.selectedColor()
         if color.isValid():
             self.chosen_bgcolor = color.name()
-            self._update_color_button_icon(self.bgcolor, self.chosen_color)
+            self._update_color_button_icon(self.bgcolor, self.chosen_bgcolor)
             self._set_layer_annotator_overlay_options()
             self._on_background_color_combobox_change()
 
@@ -744,84 +702,66 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
         if color.isValid():
             self.chosen_outline_color = color.name()
             self._update_color_button_icon(
-                self.outline_color, self.chosen_color
+                self.outline_color, self.chosen_outline_color
             )
             self._set_layer_annotator_overlay_options()
 
+    # ------------------------------------------------------------------
+    # Overlay state
+    # ------------------------------------------------------------------
+
     def _set_opacity(self):
-        self.layer_annotator_overlay.bg_color = ColorArray(
-            self.chosen_bgcolor, alpha=self.opacity_slider.value() / 100
-        )
+        if self.overlay_set:
+            self._annotator_manager.update_settings(
+                bg_color=ColorArray(
+                    self.chosen_bgcolor,
+                    alpha=self.opacity_slider.value() / 100,
+                )
+            )
 
     def _toggle_visibility(self):
-        self.layer_annotator_overlay.visible = (
-            not self.layer_annotator_overlay.visible
-        )
+        if self._annotator_manager is None:
+            return
+        # Derive the new state from the button's checked state.
+        visible = self.toggle_visibility_button.isChecked()
+        self._annotator_manager.set_visible(visible)
         self.toggle_visibility_button.setText(
-            "Hide Overlay"
-            if self.layer_annotator_overlay.visible
-            else "Show Overlay"
+            "Hide Overlay" if visible else "Show Overlay"
         )
 
     def _on_size_slider_change(self):
-        """
-        Slot function to handle changes in the size slider.
-        """
-        new_size = self.size_slider.value()
-        # Update the overlay size
         if self.overlay_set:
-            self.layer_annotator_overlay.size = new_size
+            self._annotator_manager.update_settings(
+                size=self.size_slider.value()
+            )
 
     def _set_layer_annotator_overlay_options(self):
-        """
-        Set options for LayerAnnotatorOverlay based on the widget inputs.
-        """
-        if self.overlay_set:
-            # Update the overlay properties
-            self.layer_annotator_overlay.position = (
-                self.position_combobox.currentText()
-            )
-            self.layer_annotator_overlay.x_spacer = (
-                self.x_offset_spinbox.value()
-            )
-            self.layer_annotator_overlay.y_spacer = (
-                self.y_offset_spinbox.value()
-            )
-            # get the color from the color picker
-            self.layer_annotator_overlay.color = (
-                self.chosen_color
-            )  # Set color for overlay
-            self.layer_annotator_overlay.bold = self.bold_checkbox.isChecked()
-            self.layer_annotator_overlay.italic = (
-                self.italic_checkbox.isChecked()
-            )
-            self.layer_annotator_overlay.show_background = (
-                self.bgcolor_checkbox.isChecked()
-            )
-            self.layer_annotator_overlay.bg_color = ColorArray(
-                self.chosen_bgcolor, alpha=self.opacity_slider.value() / 100
-            )
-            self.layer_annotator_overlay.show_outline = (
-                self.outline_checkbox.isChecked()
-            )
-            self.layer_annotator_overlay.outline_color = ColorArray(
-                self.chosen_outline_color
-            )
-            self.layer_annotator_overlay.outline_thickness = (
-                self.outline_size.value()
-            )
+        """Push all current widget values to every managed overlay at once."""
+        if not self.overlay_set or self._annotator_manager is None:
+            return
+        self._annotator_manager.update_settings(
+            position=self.position_combobox.currentText(),
+            color=self.chosen_color,
+            bold=self.bold_checkbox.isChecked(),
+            italic=self.italic_checkbox.isChecked(),
+            show_background=self.bgcolor_checkbox.isChecked(),
+            bg_color=ColorArray(
+                self.chosen_bgcolor,
+                alpha=self.opacity_slider.value() / 100,
+            ),
+            show_outline=self.outline_checkbox.isChecked(),
+            outline_color=ColorArray(self.chosen_outline_color),
+            outline_thickness=self.outline_size.value(),
+            size=self.size_slider.value(),
+            use_layer_color=self.color_checkbox.isChecked(),
+        )
+
+    # ------------------------------------------------------------------
+    # Signal connections
+    # ------------------------------------------------------------------
 
     def _connect_all_changes(self):
-        """
-        Connects all the widget changes to their respective slots.
-        """
         self.position_combobox.currentTextChanged.connect(
-            self._set_layer_annotator_overlay_options
-        )
-        self.x_offset_spinbox.valueChanged.connect(
-            self._set_layer_annotator_overlay_options
-        )
-        self.y_offset_spinbox.valueChanged.connect(
             self._set_layer_annotator_overlay_options
         )
         self.color.clicked.connect(self._open_color_dialog)
@@ -846,63 +786,61 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
             self._set_layer_annotator_overlay_options
         )
 
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event):
+        if self._annotator_manager is not None:
+            self._annotator_manager.close()
+        super().closeEvent(event)
+
+
+# =============================================================================
+# Remaining widgets — unchanged
+# =============================================================================
+
 
 class RenderRGBWidget(QWidget):
     def __init__(self, viewer: napari.viewer.Viewer, parent=None):
         super().__init__(parent)
         self.viewer = viewer
-
         self.layout = QVBoxLayout(self)
-
         self.filepath_label = QLabel("Output Directory:", self)
         self.layout.addWidget(self.filepath_label)
-
         self.filepath_button = QPushButton("Select Directory", self)
         self.layout.addWidget(self.filepath_button)
-
         self.export_type_label = QLabel("Export Type:", self)
         self.layout.addWidget(self.export_type_label)
-
         self.export_type_combobox = QComboBox(self)
         self.export_type_combobox.addItems(
             ["mp4", "tif", "png", "jpeg", "gif"]
         )
         self.layout.addWidget(self.export_type_combobox)
-
         self.axis_label = QLabel("Viewer Axis:", self)
         self.layout.addWidget(self.axis_label)
-
         self.axis_combobox = QComboBox(self)
         self.axis_combobox.addItem("None", None)
         self.layout.addWidget(self.axis_combobox)
-
         self.name_label = QLabel("Name:", self)
         self.layout.addWidget(self.name_label)
-
         self.name_lineedit = QLineEdit(self)
         self.name_lineedit.setText("output")
         self.layout.addWidget(self.name_lineedit)
-
         self.scale_label = QLabel("Scale Factor:", self)
         self.layout.addWidget(self.scale_label)
-
         self.scale_spinbox = QDoubleSpinBox(self)
         self.scale_spinbox.setRange(0, 100)
         self.scale_spinbox.setValue(1)
-
         self.layout.addWidget(self.scale_spinbox)
-
         self.frame_interval = QLabel("FPS:", self)
         self.layout.addWidget(self.frame_interval)
-
         self.frame_interval_spinbox = QSpinBox(self)
         self.frame_interval_spinbox.setRange(1, 1000)
         self.frame_interval_spinbox.setValue(10)
         self.layout.addWidget(self.frame_interval_spinbox)
-
         self.render_button = QPushButton("Render and Save", self)
         self.layout.addWidget(self.render_button)
-
         self.spacer = QtWidgets.QSpacerItem(
             20,
             40,
@@ -910,9 +848,7 @@ class RenderRGBWidget(QWidget):
             QtWidgets.QSizePolicy.Expanding,
         )
         self.layout.addItem(self.spacer)
-
         self.directory = Path()
-
         self.update_axis_combobox()
         self.connect_slots()
 
@@ -960,24 +896,18 @@ class LayertoRGBWidget(QWidget):
     def __init__(self, viewer: napari.viewer.Viewer, parent=None):
         super().__init__(parent)
         self.viewer = viewer
-
         self.layout = QVBoxLayout(self)
-
         self.layer_selector_label = QLabel("Select Layer(s) to convert", self)
         self.layout.addWidget(self.layer_selector_label)
         self.layer_selector = QListWidget(self)
         self.layout.addWidget(self.layer_selector)
-
         self.name_label = QLabel("Name:", self)
         self.layout.addWidget(self.name_label)
-
         self.name_lineedit = QLineEdit(self)
         self.name_lineedit.setText("output")
         self.layout.addWidget(self.name_lineedit)
-
         self.render_button = QPushButton("Convert to RGB", self)
         self.layout.addWidget(self.render_button)
-
         self.spacer = QtWidgets.QSpacerItem(
             20,
             40,
@@ -1004,7 +934,7 @@ class LayertoRGBWidget(QWidget):
 
     def on_render_button_clicked(self):
         layers = self._get_selected_layers()
-        if len(layers) == 0:
+        if not layers:
             return
         rendered_image = self.render_layers_as_rgb(layers)
         self.viewer.add_image(
@@ -1018,7 +948,6 @@ class LayertoRGBWidget(QWidget):
 
     def render_layers_as_rgb(self, layers):
         temporary_removed_layers = {}
-        # loop over all layers, position them in the center of the canvas, render them, and save them
         for layer_idx, layer in enumerate(self.viewer.layers):
             if layer in layers:
                 layer.visible = True
@@ -1026,11 +955,9 @@ class LayertoRGBWidget(QWidget):
                 temporary_removed_layers[layer_idx] = self.viewer.layers.pop(
                     layer_idx
                 )
-
         ax = [idx for idx, ax in enumerate(self.viewer.dims.range[:-2])]
-        if len(ax) == 0:
+        if not ax:
             ax = None
-        # loop over all axis
         try:
             rendered_image = render_as_rgb(self.viewer, ax, 1)
         finally:
@@ -1043,30 +970,22 @@ class SplitStackWidget(QWidget):
     def __init__(self, viewer: napari.viewer.Viewer, parent=None):
         super().__init__(parent)
         self.viewer = viewer
-
         self.layout = QVBoxLayout(self)
-
         self.layer_label = QLabel("Layer:", self)
         self.layout.addWidget(self.layer_label)
-
         self.layer_combobox = QComboBox(self)
         self.layout.addWidget(self.layer_combobox)
-
         self.axis_label = QLabel("Split Axis:", self)
         self.layout.addWidget(self.axis_label)
-
         self.axis_combobox = QComboBox(self)
         self.layout.addWidget(self.axis_combobox)
-
         self.remove_original_checkbox = QtWidgets.QCheckBox(
             "Remove original layer"
         )
         self.remove_original_checkbox.setChecked(True)
         self.layout.addWidget(self.remove_original_checkbox)
-
         self.split_button = QPushButton("Split", self)
         self.layout.addWidget(self.split_button)
-
         self.spacer = QtWidgets.QSpacerItem(
             20,
             40,
@@ -1074,17 +993,12 @@ class SplitStackWidget(QWidget):
             QtWidgets.QSizePolicy.Expanding,
         )
         self.layout.addItem(self.spacer)
-
         self._update_layer_combobox()
         self._connect_slots()
 
     def _connect_slots(self):
-        self.viewer.layers.events.inserted.connect(
-            self._update_layer_combobox
-        )
-        self.viewer.layers.events.removed.connect(
-            self._update_layer_combobox
-        )
+        self.viewer.layers.events.inserted.connect(self._update_layer_combobox)
+        self.viewer.layers.events.removed.connect(self._update_layer_combobox)
         self.layer_combobox.currentIndexChanged.connect(
             self._update_axis_combobox
         )
@@ -1102,12 +1016,12 @@ class SplitStackWidget(QWidget):
         if idx < 0 or idx >= len(self.viewer.layers):
             return
         layer = self.viewer.layers[idx]
-        ndim = layer.data.ndim
-        axis_labels = self.viewer.dims.axis_labels
-        for i in range(ndim):
+        for i in range(layer.data.ndim):
+            axis_labels = self.viewer.dims.axis_labels
             axis_name = axis_labels[i] if i < len(axis_labels) else str(i)
-            label = f"{axis_name} (size {layer.data.shape[i]})"
-            self.axis_combobox.addItem(label, i)
+            self.axis_combobox.addItem(
+                f"{axis_name} (size {layer.data.shape[i]})", i
+            )
 
     def _on_split(self):
         idx = self.layer_combobox.currentIndex()
@@ -1120,24 +1034,19 @@ class SplitStackWidget(QWidget):
         data = layer.data
         base_name = layer.name
         is_labels = isinstance(layer, labels.Labels)
-
-        # collect properties that survive the dimension drop
         scale = [s for i, s in enumerate(layer.scale) if i != axis]
         translate = [t for i, t in enumerate(layer.translate) if i != axis]
-
         kwargs = {"scale": scale, "translate": translate}
         if not is_labels:
             kwargs["contrast_limits"] = layer.contrast_limits
             kwargs["colormap"] = layer.colormap.name
             kwargs["blending"] = layer.blending
-
         add_fn = self.viewer.add_labels if is_labels else self.viewer.add_image
         for i in range(data.shape[axis]):
             slicing = tuple(
                 slice(None) if a != axis else i for a in range(data.ndim)
             )
             add_fn(data[slicing], name=f"{base_name}_{i}", **kwargs)
-
         if self.remove_original_checkbox.isChecked():
             self.viewer.layers.remove(layer)
 

--- a/src/napari_timestamper/_widget.py
+++ b/src/napari_timestamper/_widget.py
@@ -1007,6 +1007,12 @@ class SplitStackWidget(QWidget):
         self.axis_combobox = QComboBox(self)
         self.layout.addWidget(self.axis_combobox)
 
+        self.remove_original_checkbox = QtWidgets.QCheckBox(
+            "Remove original layer"
+        )
+        self.remove_original_checkbox.setChecked(True)
+        self.layout.addWidget(self.remove_original_checkbox)
+
         self.split_button = QPushButton("Split", self)
         self.layout.addWidget(self.split_button)
 
@@ -1080,6 +1086,9 @@ class SplitStackWidget(QWidget):
                 slice(None) if a != axis else i for a in range(data.ndim)
             )
             add_fn(data[slicing], name=f"{base_name}_{i}", **kwargs)
+
+        if self.remove_original_checkbox.isChecked():
+            self.viewer.layers.remove(layer)
 
 
 if __name__ == "__main__":

--- a/src/napari_timestamper/_widget.py
+++ b/src/napari_timestamper/_widget.py
@@ -79,12 +79,9 @@ class TimestampWidget(QtWidgets.QWidget):
             try:
                 self.viewer._overlays["timestamp"]
             except KeyError:
+                overlay_to_visual[TimestampOverlay] = VispyTimestampOverlay
                 self.viewer._overlays["timestamp"] = TimestampOverlay(
                     visible=True
-                )
-                overlay_to_visual[TimestampOverlay] = VispyTimestampOverlay
-                self.viewer.window._qt_viewer.canvas._add_overlay_to_visual(
-                    self.viewer._overlays["timestamp"]
                 )
             self.timestamp_overlay = self.viewer._overlays["timestamp"]
             self._set_timestamp_overlay_options()
@@ -433,15 +430,12 @@ class LayerAnnotationsWidget(QtWidgets.QWidget):
             try:
                 self.viewer._overlays["LayerAnnotator"]
             except KeyError:
-                self.viewer._overlays[
-                    "LayerAnnotator"
-                ] = LayerAnnotatorOverlay(visible=True)
                 overlay_to_visual[
                     LayerAnnotatorOverlay
                 ] = VispyLayerAnnotatorOverlay
-                self.viewer.window._qt_viewer.canvas._add_overlay_to_visual(
-                    self.viewer._overlays["LayerAnnotator"]
-                )
+                self.viewer._overlays[
+                    "LayerAnnotator"
+                ] = LayerAnnotatorOverlay(visible=True)
             self.layer_annotator_overlay = self.viewer._overlays[
                 "LayerAnnotator"
             ]

--- a/src/napari_timestamper/napari.yaml
+++ b/src/napari_timestamper/napari.yaml
@@ -14,6 +14,9 @@ contributions:
     - id: napari-timestamper.render_to_layer
       python_name: napari_timestamper._widget:LayertoRGBWidget
       title: Convert to RGB layer
+    - id: napari-timestamper.split_stack
+      python_name: napari_timestamper._widget:SplitStackWidget
+      title: Split Stack
   widgets:
     - command: napari-timestamper.timestamper
       display_name: Timestamper
@@ -23,3 +26,5 @@ contributions:
       display_name: Export RGB stack
     - command: napari-timestamper.render_to_layer
       display_name: Convert to RGB layer
+    - command: napari-timestamper.split_stack
+      display_name: Split Stack

--- a/src/napari_timestamper/render_as_rgb.py
+++ b/src/napari_timestamper/render_as_rgb.py
@@ -35,10 +35,10 @@ def render_as_rgb(
                 scale_factor=upsample_factor, flash=False
             ).shape
             rgb = np.zeros(
-                (viewer.dims.range[axis][1].astype(int) + 1, *target_shape),
+                (int(viewer.dims.range[axis][1]) + 1, *target_shape),
                 dtype=np.uint8,
             )
-            for j in range(viewer.dims.range[axis][1].astype(int) + 1):
+            for j in range(int(viewer.dims.range[axis][1]) + 1):
                 viewer.dims.set_current_step(axis, j)
                 rendered_img = viewer.export_figure(
                     scale_factor=upsample_factor, flash=False
@@ -51,13 +51,13 @@ def render_as_rgb(
             rgb = np.zeros(
                 (
                     len(axis),
-                    viewer.dims.range[axis[0]][1].astype(int) + 1,
+                    int(viewer.dims.range[axis[0]][1]) + 1,
                     *target_shape,
                 ),
                 dtype=np.uint8,
             )
             for ax in axis:
-                for j in range(viewer.dims.range[ax][1].astype(int) + 1):
+                for j in range(int(viewer.dims.range[ax][1]) + 1):
                     viewer.dims.set_current_step(ax, j)
                     rendered_img = viewer.export_figure(
                         scale_factor=upsample_factor, flash=False

--- a/src/napari_timestamper/text_visual.py
+++ b/src/napari_timestamper/text_visual.py
@@ -210,7 +210,7 @@ class MultiRectVisual(Mesh):
 
 
 class TextWithBoxVisual(Compound):
-    RECTANGLE_SCALER = 2
+    RECTANGLE_SCALER = 3
 
     def __init__(
         self,
@@ -412,7 +412,9 @@ class TextWithBoxVisual(Compound):
     @font_size.setter
     def font_size(self, size: int):
         self._textvisual.font_size = size * self.scale_factor
-        self._rectagles_visual.h = size * self.rectangles_scale_factor
+        self._rectagles_visual.h = (
+            size * self.RECTANGLE_SCALER * self.rectangles_scale_factor
+        )
 
     @property
     def pos(self):
@@ -526,7 +528,7 @@ class TextWithBoxVisual(Compound):
         text_pos = [
             (
                 pos_x[i],
-                pos_y[i] + 0.35 * font_size * self.rectangles_scale_factor,
+                pos_y[i] + 0.5 * font_size * self.rectangles_scale_factor,
             )
             for i in range(len(pos_x))
         ]

--- a/src/napari_timestamper/utils.py
+++ b/src/napari_timestamper/utils.py
@@ -9,7 +9,7 @@ def _find_grid_offsets(viewer):
     extent = viewer._sliced_extent_world_augmented
     n_layers = len(viewer.layers)
     for i, layer in enumerate(viewer.layers):
-        i_row, i_column = viewer.grid.position(n_layers - 1 - i, n_layers)
+        i_row, i_column = viewer.grid.position(i, n_layers)
         # viewer._subplot(layer, (i_row, i_column), extent)
         scene_shift = extent[1] - extent[0]
         translate_2d = np.multiply(scene_shift[-2:], (i_row, i_column))

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py{39,310,311, 312, 313}-{linux,macos,windows}
+envlist = py{310,311, 312, 313}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
- **Napari 0.7.0 compatibility**: Updated overlay registration to use the new system (register visual mapping before creating overlay, removed manual `_add_overlay_to_visual` calls), migrated `qt_viewer` to `_qt_viewer`, added pydantic `ConfigDict(arbitrary_types_allowed=True)` to overlay models, fixed `dims.range` int conversion, and fixed grid position calculation.
- **New Split Stack widget**: Added `SplitStackWidget` that splits a multi-dimensional layer along a user-selected axis into individual layers, with an option to remove the original layer afterward.
- **Layer selection for annotations**: Added a checkbox-based layer selector to `LayerAnnotationsWidget`, allowing users to choose which layers are annotated instead of always annotating all visible layers.
- **Improved time axis selector**: Replaced the time axis `QSpinBox` with a `QComboBox` populated from the viewer's dimension axis labels for a more intuitive selection.
- **Overlay rendering fixes**: Fixed background/outline visibility in 3D mode, corrected x_spacer for center positions, adjusted rectangle scaling and text positioning, added guards against empty layer annotations, and simplified `_on_size_change` logic.

**Attention: Grid view and hence layer annotation on grid view is broken.** 

